### PR TITLE
LinkML schema requirement for models

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -118,8 +118,7 @@ services:
         condition: service_started
     build: ./model_server
     environment:
-      - MODEL_SERVER_ONTOLOGY_MAX_BYTES=314572800  # 300MB - the largest size ontology supported by linkml schemas reachable_from
-      - MODEL_SERVER_ONTOLOGY_CACHE_MAX_BYTES=1073741824 # 1G - total size of stored ontologies for linkml schema reachable_from before cache eviction (LRU)
+      - MODEL_SERVER_ONTOLOGY_MAX_BYTES=314572800  # 300MB - max size for a downloaded ontology used in reachable_from expansion
     volumes:
       - shared_tmp:/shared-tmp
       - /var/run/docker.sock:/var/run/docker.sock

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -117,6 +117,9 @@ services:
       model_server_db:
         condition: service_started
     build: ./model_server
+    environment:
+      - MODEL_SERVER_ONTOLOGY_MAX_BYTES=314572800  # 300MB - the largest size ontology supported by linkml schemas reachable_from
+      - MODEL_SERVER_ONTOLOGY_CACHE_MAX_BYTES=1073741824 # 1G - total size of stored ontologies for linkml schema reachable_from before cache eviction (LRU)
     volumes:
       - shared_tmp:/shared-tmp
       - /var/run/docker.sock:/var/run/docker.sock

--- a/app/mcp_server/mcp_server/main.py
+++ b/app/mcp_server/mcp_server/main.py
@@ -256,6 +256,10 @@ def get_model_metadata(image_tag: str) -> Dict[str, Any]:
         - authors: Model authors
         - examples: Example input records (shows exact format expected)
         - readme: Full README documentation with feature descriptions
+        - input_schema: Original LinkML input schema (if provided)
+        - output_schema: Original LinkML output schema (if provided)
+        - input_schema_expanded: Expanded input schema with reachable_from resolved
+        - output_schema_expanded: Expanded output schema with reachable_from resolved
     """
     url = f"{MODEL_SERVER_URL}/models/{image_tag}"
     response = requests.get(url, timeout=10)
@@ -632,4 +636,3 @@ if __name__ == "__main__":
     
     # Use streamable-http transport
     mcp.run(transport="streamable-http", host=host, port=port)
-

--- a/app/model_server/model_server/main.py
+++ b/app/model_server/model_server/main.py
@@ -11,7 +11,14 @@ from pydantic import BaseModel
 import docker
 from pymongo import MongoClient
 from typing import List, Any, Optional, Dict
-from model_server.validation import ValidationError, validate_items, extract_target_class, normalize_schema_to_string, parse_schema
+from model_server.validation import (
+    ValidationError,
+    validate_items,
+    extract_target_class,
+    normalize_schema_to_string,
+    parse_schema,
+    expand_and_normalize_schema,
+)
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -97,10 +104,11 @@ def _run_model_container(image: str, input_data: any, model_metadata: dict = Non
         if model_metadata and model_metadata.get("input_schema"):
             logger.info(f"Validating input data against schema for {image}")
             try:
-                target_class = extract_target_class(model_metadata["input_schema"])
+                input_schema = model_metadata.get("input_schema_expanded") or model_metadata.get("input_schema")
+                target_class = extract_target_class(input_schema)
                 validate_items(
                     items=input_data,
-                    schema=model_metadata["input_schema"],
+                    schema=input_schema,
                     target_class_name=target_class,
                     data_type="input"
                 )
@@ -209,12 +217,13 @@ def _run_model_container(image: str, input_data: any, model_metadata: dict = Non
         if model_metadata and model_metadata.get("output_schema"):
             logger.info(f"Validating output data against schema for {image}")
             try:
-                target_class = extract_target_class(model_metadata["output_schema"])
+                output_schema = model_metadata.get("output_schema_expanded") or model_metadata.get("output_schema")
+                target_class = extract_target_class(output_schema)
                 # Handle both list and single-item outputs
                 output_list = predictions if isinstance(predictions, list) else [predictions]
                 validate_items(
                     items=output_list,
-                    schema=model_metadata["output_schema"],
+                    schema=output_schema,
                     target_class_name=target_class,
                     data_type="output"
                 )
@@ -399,14 +408,27 @@ def _register_model_internal(metadata: dict) -> dict:
         raise Exception(f"Image not found locally: {image}")
 
     try:
+        # Expand schemas if reachable_from is present (hard fail if expansion fails)
+        try:
+            original_input_schema, expanded_input_schema = expand_and_normalize_schema(metadata.get("input_schema"))
+            original_output_schema, expanded_output_schema = expand_and_normalize_schema(metadata.get("output_schema"))
+        except Exception as e:
+            raise Exception(f"Schema expansion failed: {e}")
+
+        metadata["input_schema"] = original_input_schema
+        metadata["input_schema_expanded"] = expanded_input_schema
+        metadata["output_schema"] = original_output_schema
+        metadata["output_schema_expanded"] = expanded_output_schema
+
         # Validate examples against input schema before testing
         if metadata.get("input_schema"):
             logger.info(f"Validating examples against input schema for {image}")
             try:
-                target_class = extract_target_class(metadata["input_schema"])
+                schema_for_validation = metadata.get("input_schema_expanded") or metadata.get("input_schema")
+                target_class = extract_target_class(schema_for_validation)
                 validate_items(
                     items=metadata["examples"],
-                    schema=metadata["input_schema"],
+                    schema=schema_for_validation,
                     target_class_name=target_class,
                     data_type="example input"
                 )
@@ -436,7 +458,9 @@ def _register_model_internal(metadata: dict) -> dict:
             "readme": metadata["readme"],
             "examples": metadata["examples"],
             "input_schema": metadata.get("input_schema"),
-            "output_schema": metadata.get("output_schema")
+            "input_schema_expanded": metadata.get("input_schema_expanded"),
+            "output_schema": metadata.get("output_schema"),
+            "output_schema_expanded": metadata.get("output_schema_expanded"),
         }
         # Upsert (replace if exists, insert if new)
         models_collection.replace_one({"image": image}, doc, upsert=True)
@@ -449,7 +473,11 @@ def _register_model_internal(metadata: dict) -> dict:
             "registration_logs": {
                 "stdout": result["stdout"],
                 "stderr": result["stderr"]
-            }
+            },
+            "input_schema": schema_to_response_format(metadata.get("input_schema")),
+            "output_schema": schema_to_response_format(metadata.get("output_schema")),
+            "input_schema_expanded": schema_to_response_format(metadata.get("input_schema_expanded")),
+            "output_schema_expanded": schema_to_response_format(metadata.get("output_schema_expanded")),
         }
     except Exception as e:
         logger.error(f"Registration failed for {image}: {e}")
@@ -694,6 +722,8 @@ def list_models():
             "examples": m.get("examples", []),
             "has_input_schema": m.get("input_schema") is not None,
             "has_output_schema": m.get("output_schema") is not None,
+            "has_input_schema_expanded": m.get("input_schema_expanded") is not None,
+            "has_output_schema_expanded": m.get("output_schema_expanded") is not None,
         })
     return models
 
@@ -713,4 +743,6 @@ def model_info(image_tag: str):
         "readme": m.get("readme", ""),
         "input_schema": schema_to_response_format(m.get("input_schema")),
         "output_schema": schema_to_response_format(m.get("output_schema")),
+        "input_schema_expanded": schema_to_response_format(m.get("input_schema_expanded")),
+        "output_schema_expanded": schema_to_response_format(m.get("output_schema_expanded")),
     }

--- a/app/model_server/model_server/main.py
+++ b/app/model_server/model_server/main.py
@@ -10,11 +10,37 @@ from fastapi import FastAPI, HTTPException, Body
 from pydantic import BaseModel
 import docker
 from pymongo import MongoClient
-from typing import List, Any, Optional
+from typing import List, Any, Optional, Dict
+from model_server.validation import ValidationError, validate_items, extract_target_class, normalize_schema_to_string, parse_schema
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def schema_to_response_format(schema: Optional[str]) -> Optional[Dict[str, Any]]:
+    """
+    Convert a stored schema string to a dict for API responses.
+
+    Schemas are stored as strings in MongoDB (either from container YAML/JSON files
+    or from API-provided dicts that were normalized to JSON strings).
+    For API responses, we parse them back to dicts so they appear as proper JSON objects.
+
+    Args:
+        schema: Schema string from MongoDB, or None
+
+    Returns:
+        Parsed schema dict, or None if input was None
+    """
+    if schema is None:
+        return None
+    try:
+        return parse_schema(schema)
+    except Exception as e:
+        logger.warning(f"Failed to parse schema for response: {e}")
+        # Return the raw string if parsing fails (shouldn't happen with valid schemas)
+        return {"_raw": schema, "_parse_error": str(e)}
+
 
 app = FastAPI()
 client = docker.from_env()
@@ -38,6 +64,8 @@ class RegisterRequest(BaseModel):
     authors: str
     examples: Optional[List[Any]] = None  # Optional - can be extracted from container
     readme: Optional[str] = None  # Optional - can be extracted from container
+    input_schema: Optional[Dict[str, Any]] = None  # Optional - LinkML schema as JSON object (or extract from container .yaml/.json)
+    output_schema: Optional[Dict[str, Any]] = None  # Optional - LinkML schema as JSON object (or extract from container .yaml/.json)
 
 def wait_for_mongodb():
     """Wait for MongoDB to be ready"""
@@ -55,16 +83,33 @@ def wait_for_mongodb():
                 logger.error(f"Failed to connect to MongoDB after {max_retries} attempts: {e}")
                 raise
 
-def _run_model_container(image: str, input_data: any) -> dict:
+def _run_model_container(image: str, input_data: any, model_metadata: dict = None) -> dict:
     """Run a model container with file-based I/O and capture stdout/stderr"""
     session_id = uuid.uuid4().hex
     input_file = f"input_{session_id}.json"
     output_file = f"output_{session_id}.json"
-    
+
     input_path = os.path.join("/shared-tmp", input_file)
     output_path = os.path.join("/shared-tmp", output_file)
-    
+
     try:
+        # Validate input data against schema if available
+        if model_metadata and model_metadata.get("input_schema"):
+            logger.info(f"Validating input data against schema for {image}")
+            try:
+                target_class = extract_target_class(model_metadata["input_schema"])
+                validate_items(
+                    items=input_data,
+                    schema=model_metadata["input_schema"],
+                    target_class_name=target_class,
+                    data_type="input"
+                )
+                logger.info(f"Input validation passed for {image}")
+            except ValidationError:
+                raise  # Re-raise ValidationError for proper handling
+            except Exception as e:
+                raise ValidationError(f"Input validation failed: {e}", [])
+
         # Write input data to file
         with open(input_path, "w") as f:
             json.dump(input_data, f)
@@ -156,12 +201,32 @@ def _run_model_container(image: str, input_data: any) -> dict:
         # Read predictions from output file
         if not os.path.exists(output_path):
             raise Exception(f"Model did not create output file: {output_file}")
-        
+
         with open(output_path, 'r') as f:
             predictions = json.load(f)
-        
+
+        # Validate output data against schema if available
+        if model_metadata and model_metadata.get("output_schema"):
+            logger.info(f"Validating output data against schema for {image}")
+            try:
+                target_class = extract_target_class(model_metadata["output_schema"])
+                # Handle both list and single-item outputs
+                output_list = predictions if isinstance(predictions, list) else [predictions]
+                validate_items(
+                    items=output_list,
+                    schema=model_metadata["output_schema"],
+                    target_class_name=target_class,
+                    data_type="output"
+                )
+                logger.info(f"Output validation passed for {image}")
+            except ValidationError as e:
+                # Output validation failure is a model implementation error
+                raise Exception(f"Output validation failed (model does not conform to declared schema): {e}")
+            except Exception as e:
+                raise Exception(f"Output validation failed: {e}")
+
         logger.info(f"Model {image} execution successful")
-        
+
         return {
             "predictions": predictions,
             "stdout": stdout_output,
@@ -175,6 +240,8 @@ def _run_model_container(image: str, input_data: any) -> dict:
         
     except json.JSONDecodeError as e:
         raise Exception(f"Model output file contains invalid JSON: {e}")
+    except ValidationError:
+        raise  # Re-raise ValidationError for proper 400 error handling
     except Exception as e:
         # If output file doesn't exist, try to get any error info from stdout
         error_info = container_result.decode('utf-8') if 'container_result' in locals() else "No output"
@@ -186,19 +253,25 @@ def _run_model_container(image: str, input_data: any) -> dict:
                 os.remove(temp_file)
 
 def _extract_container_metadata(image: str) -> dict:
-    """Extract readme and examples from container files"""
+    """Extract readme, examples, and schemas from container files.
+
+    Schemas can be provided as either YAML (.yaml) or JSON (.json) files.
+    YAML is checked first for backwards compatibility.
+    """
     temp_readme_path = None
     temp_examples_path = None
     metadata = {}
-    
+
     try:
         logger.info(f"Attempting to extract metadata from container: {image}")
-        
+
         # Create unique temp files for this extraction
         session_id = uuid.uuid4().hex
         temp_readme_path = os.path.join("/shared-tmp", f"readme_{session_id}.md")
         temp_examples_path = os.path.join("/shared-tmp", f"examples_{session_id}.json")
-        
+        temp_input_schema_path = os.path.join("/shared-tmp", f"input_schema_{session_id}.yaml")
+        temp_output_schema_path = os.path.join("/shared-tmp", f"output_schema_{session_id}.yaml")
+
         # Try to copy README.md from container
         try:
             client.containers.run(
@@ -210,15 +283,15 @@ def _extract_container_metadata(image: str) -> dict:
                 remove=True,
                 detach=False
             )
-            
+
             if os.path.exists(temp_readme_path):
                 with open(temp_readme_path, 'r') as f:
                     metadata['readme'] = f.read()
                 logger.info(f"Extracted README from container: {image}")
-            
+
         except Exception as e:
             logger.debug(f"No README.md found in container {image}: {e}")
-        
+
         # Try to copy examples.json from container
         try:
             client.containers.run(
@@ -230,23 +303,85 @@ def _extract_container_metadata(image: str) -> dict:
                 remove=True,
                 detach=False
             )
-            
+
             if os.path.exists(temp_examples_path):
                 with open(temp_examples_path, 'r') as f:
                     examples_data = json.load(f)
                 metadata['examples'] = examples_data
                 logger.info(f"Extracted examples from container: {image}")
-            
+
         except Exception as e:
             logger.debug(f"No examples.json found in container {image}: {e}")
-        
+
+        # Try to copy input_schema from container (YAML or JSON)
+        input_schema_extracted = False
+        for ext in ['.yaml', '.json']:
+            if input_schema_extracted:
+                break
+            try:
+                temp_input_schema_path = os.path.join("/shared-tmp", f"input_schema_{session_id}{ext}")
+                client.containers.run(
+                    image,
+                    command=["cp", f"/app/input_schema{ext}", f"/shared-tmp/input_schema_{session_id}{ext}"],
+                    volumes={
+                        "app_shared_tmp": {"bind": "/shared-tmp", "mode": "rw"}
+                    },
+                    remove=True,
+                    detach=False
+                )
+
+                if os.path.exists(temp_input_schema_path):
+                    with open(temp_input_schema_path, 'r') as f:
+                        metadata['input_schema'] = f.read()
+                    logger.info(f"Extracted input_schema{ext} from container: {image}")
+                    input_schema_extracted = True
+                    # Clean up this temp file
+                    os.remove(temp_input_schema_path)
+
+            except Exception as e:
+                logger.debug(f"No input_schema{ext} found in container {image}: {e}")
+                # Clean up temp file if it exists
+                if os.path.exists(temp_input_schema_path):
+                    os.remove(temp_input_schema_path)
+
+        # Try to copy output_schema from container (YAML or JSON)
+        output_schema_extracted = False
+        for ext in ['.yaml', '.json']:
+            if output_schema_extracted:
+                break
+            try:
+                temp_output_schema_path = os.path.join("/shared-tmp", f"output_schema_{session_id}{ext}")
+                client.containers.run(
+                    image,
+                    command=["cp", f"/app/output_schema{ext}", f"/shared-tmp/output_schema_{session_id}{ext}"],
+                    volumes={
+                        "app_shared_tmp": {"bind": "/shared-tmp", "mode": "rw"}
+                    },
+                    remove=True,
+                    detach=False
+                )
+
+                if os.path.exists(temp_output_schema_path):
+                    with open(temp_output_schema_path, 'r') as f:
+                        metadata['output_schema'] = f.read()
+                    logger.info(f"Extracted output_schema{ext} from container: {image}")
+                    output_schema_extracted = True
+                    # Clean up this temp file
+                    os.remove(temp_output_schema_path)
+
+            except Exception as e:
+                logger.debug(f"No output_schema{ext} found in container {image}: {e}")
+                # Clean up temp file if it exists
+                if os.path.exists(temp_output_schema_path):
+                    os.remove(temp_output_schema_path)
+
         return metadata
-        
+
     except Exception as e:
         logger.warning(f"Failed to extract metadata from container {image}: {e}")
         return {}
     finally:
-        # Clean up temporary files
+        # Clean up temporary files (schema temp files are cleaned up in their respective loops)
         for temp_file in [temp_readme_path, temp_examples_path]:
             if temp_file and os.path.exists(temp_file):
                 os.remove(temp_file)
@@ -254,7 +389,7 @@ def _extract_container_metadata(image: str) -> dict:
 def _register_model_internal(metadata: dict) -> dict:
     """Internal model registration function that can be called during startup"""
     image = metadata["image"]
-    
+
     # 1. Check if image exists locally
     try:
         client.images.get(image)
@@ -264,25 +399,44 @@ def _register_model_internal(metadata: dict) -> dict:
         raise Exception(f"Image not found locally: {image}")
 
     try:
-        # Test the model with provided examples
+        # Validate examples against input schema before testing
+        if metadata.get("input_schema"):
+            logger.info(f"Validating examples against input schema for {image}")
+            try:
+                target_class = extract_target_class(metadata["input_schema"])
+                validate_items(
+                    items=metadata["examples"],
+                    schema=metadata["input_schema"],
+                    target_class_name=target_class,
+                    data_type="example input"
+                )
+                logger.info(f"Example validation passed for {image}")
+            except ValidationError as e:
+                raise Exception(f"Examples do not match input schema: {e}")
+            except Exception as e:
+                raise Exception(f"Failed to validate examples against input schema: {e}")
+
+        # Test the model with provided examples (pass metadata for output validation)
         logger.info(f"Testing model {image} with examples...")
-        result = _run_model_container(image, metadata["examples"])
-        
+        result = _run_model_container(image, metadata["examples"], metadata)
+
         preds = result["predictions"]
         logger.info(f"Model {image} test successful")
-        
+
         # Log any stderr output during registration
         if result["stderr"]:
             logger.info(f"Model {image} stderr during registration: {result['stderr']}")
 
-        # Store in MongoDB
+        # Store in MongoDB (including schemas)
         doc = {
             "image": image,
             "title": metadata["title"],
             "short_description": metadata["short_description"],
             "authors": metadata["authors"],
             "readme": metadata["readme"],
-            "examples": metadata["examples"]
+            "examples": metadata["examples"],
+            "input_schema": metadata.get("input_schema"),
+            "output_schema": metadata.get("output_schema")
         }
         # Upsert (replace if exists, insert if new)
         models_collection.replace_one({"image": image}, doc, upsert=True)
@@ -304,63 +458,76 @@ def _register_model_internal(metadata: dict) -> dict:
 def load_builtin_models():
     """Load and register built-in models from metadata files"""
     logger.info("Starting auto-registration of built-in models...")
-    
+
     if not os.path.exists(BUILTIN_MODELS_PATH):
         logger.warning(f"Built-in models path does not exist: {BUILTIN_MODELS_PATH}")
         return
-    
+
     # Find all model_metadata.json files
     metadata_files = glob.glob(os.path.join(BUILTIN_MODELS_PATH, "*/model_metadata.json"))
-    
+
     if not metadata_files:
         logger.warning(f"No model metadata files found in: {BUILTIN_MODELS_PATH}")
         return
-    
+
     registered_count = 0
     failed_count = 0
-    
+
     for metadata_file in metadata_files:
         model_name = Path(metadata_file).parent.name
         try:
             logger.info(f"Loading metadata for model: {model_name}")
             with open(metadata_file, 'r') as f:
                 base_metadata = json.load(f)
-            
+
             # Extract container metadata if available
             image = base_metadata["image"]
             container_metadata = _extract_container_metadata(image)
-            
-            # Merge metadata with container fallback
+
+            # Merge metadata with container fallback (including schemas)
             metadata = {
                 "image": base_metadata["image"],
                 "title": base_metadata["title"],
                 "short_description": base_metadata["short_description"],
                 "authors": base_metadata["authors"],
                 "examples": base_metadata.get("examples") or container_metadata.get("examples"),
-                "readme": base_metadata.get("readme") or container_metadata.get("readme")
+                "readme": base_metadata.get("readme") or container_metadata.get("readme"),
+                "input_schema": base_metadata.get("input_schema") or container_metadata.get("input_schema"),
+                "output_schema": base_metadata.get("output_schema") or container_metadata.get("output_schema")
             }
-            
+
             # Validate required fields
             if not metadata["examples"]:
                 logger.error(f"No examples found for {model_name} in JSON file or container")
                 failed_count += 1
                 continue
-            
+
             if not metadata["readme"]:
                 logger.error(f"No README found for {model_name} in JSON file or container")
                 failed_count += 1
                 continue
-            
+
+            # Schemas are required
+            if not metadata["input_schema"]:
+                logger.error(f"No input_schema found for {model_name} in JSON file or container")
+                failed_count += 1
+                continue
+
+            if not metadata["output_schema"]:
+                logger.error(f"No output_schema found for {model_name} in JSON file or container")
+                failed_count += 1
+                continue
+
             # Register the model
             _register_model_internal(metadata)
             registered_count += 1
-            
+
         except Exception as e:
             logger.error(f"Failed to register built-in model {model_name}: {e}")
             failed_count += 1
-    
+
     logger.info(f"Built-in model registration complete: {registered_count} successful, {failed_count} failed")
-    
+
     if failed_count > 0:
         raise Exception(f"Failed to register {failed_count} built-in models")
 
@@ -436,33 +603,52 @@ def register_model(req: RegisterRequest):
             client.images.pull(req.image)
         except Exception:
             pass  # Image might already be local
-        
+
         # Extract metadata from container if available
         container_metadata = _extract_container_metadata(req.image)
-        
+
         # Build final metadata with API override priority
+        # API schemas are dicts, container schemas are strings - normalize all to strings for consistent storage
+        api_input_schema = normalize_schema_to_string(req.input_schema) if req.input_schema is not None else None
+        api_output_schema = normalize_schema_to_string(req.output_schema) if req.output_schema is not None else None
+
         metadata = {
             "image": req.image,
             "title": req.title,
             "short_description": req.short_description,
             "authors": req.authors,
             "examples": req.examples if req.examples is not None else container_metadata.get("examples"),
-            "readme": req.readme if req.readme is not None else container_metadata.get("readme")
+            "readme": req.readme if req.readme is not None else container_metadata.get("readme"),
+            "input_schema": api_input_schema if api_input_schema is not None else container_metadata.get("input_schema"),
+            "output_schema": api_output_schema if api_output_schema is not None else container_metadata.get("output_schema")
         }
-        
+
         # Validate that required fields are present
         if metadata["examples"] is None:
             raise HTTPException(
-                status_code=400, 
+                status_code=400,
                 detail="Examples are required. Provide via API 'examples' field or include /app/examples.json in container."
             )
-        
+
         if metadata["readme"] is None:
             raise HTTPException(
-                status_code=400, 
+                status_code=400,
                 detail="README is required. Provide via API 'readme' field or include /app/README.md in container."
             )
-        
+
+        # Schemas are required
+        if metadata["input_schema"] is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Input schema is required. Provide via API 'input_schema' field (JSON format) or include /app/input_schema.yaml or /app/input_schema.json in container."
+            )
+
+        if metadata["output_schema"] is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Output schema is required. Provide via API 'output_schema' field (JSON format) or include /app/output_schema.yaml or /app/output_schema.json in container."
+            )
+
         return _register_model_internal(metadata)
     except HTTPException:
         raise  # Re-raise HTTP exceptions as-is
@@ -480,20 +666,24 @@ def predict(
     if not m:
         raise HTTPException(status_code=404, detail="Model not registered")
 
-    # 2. Run the model with file-based I/O
+    # 2. Run the model with file-based I/O (pass model metadata for validation)
     try:
-        result = _run_model_container(image, input)
+        result = _run_model_container(image, input, m)
         return {
             "predictions": result["predictions"],
             "stdout": result["stdout"],
             "stderr": result["stderr"]
         }
+    except ValidationError as e:
+        # Input validation failed - return 400 Bad Request
+        raise HTTPException(status_code=400, detail=f"Validation error: {e}")
     except Exception as e:
+        # Other errors (including output validation) - return 500
         raise HTTPException(status_code=500, detail=f"Prediction failed: {e}")
 
 @app.get("/models")
 def list_models():
-    # Return all models with core metadata (not including README)
+    # Return all models with core metadata (not including README or full schemas)
     models = []
     for m in models_collection.find({}, {"_id": 0}):
         models.append({
@@ -502,6 +692,8 @@ def list_models():
             "short_description": m.get("short_description", ""),
             "authors": m.get("authors", ""),
             "examples": m.get("examples", []),
+            "has_input_schema": m.get("input_schema") is not None,
+            "has_output_schema": m.get("output_schema") is not None,
         })
     return models
 
@@ -510,7 +702,8 @@ def model_info(image_tag: str):
     m = models_collection.find_one({"image": image_tag})
     if not m:
         raise HTTPException(status_code=404, detail="Model not found")
-    # Build response with all metadata, including README
+    # Build response with all metadata, including README and schemas
+    # Parse schema strings to dicts so they appear as proper JSON objects in the response
     return {
         "image": m["image"],
         "title": m.get("title", ""),
@@ -518,4 +711,6 @@ def model_info(image_tag: str):
         "authors": m.get("authors", ""),
         "examples": m.get("examples", []),
         "readme": m.get("readme", ""),
+        "input_schema": schema_to_response_format(m.get("input_schema")),
+        "output_schema": schema_to_response_format(m.get("output_schema")),
     }

--- a/app/model_server/model_server/validation.py
+++ b/app/model_server/model_server/validation.py
@@ -1,0 +1,240 @@
+"""
+LinkML-based validation for model inputs and outputs.
+
+Schemas can be provided in multiple formats:
+- API input: JSON object (dict) - preferred for API registration
+- Container files: Both .yaml and .json files are supported (read as strings)
+
+Internal functions accept Union[str, Dict] to handle both cases.
+"""
+import logging
+import tempfile
+import os
+import json
+from typing import List, Dict, Any, Union, Optional
+import yaml
+from linkml.validator import validate
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_schema_to_string(schema: Union[str, Dict[str, Any], None]) -> Optional[str]:
+    """
+    Normalize a schema to a string for internal storage and LinkML validation.
+
+    - If dict (from API): convert to JSON string
+    - If string (from container file): return as-is
+    - If None: return None
+
+    Args:
+        schema: Schema as dict, string, or None
+
+    Returns:
+        Optional[str]: Schema as string, or None if input was None
+    """
+    if schema is None:
+        return None
+    if isinstance(schema, dict):
+        return json.dumps(schema)
+    return schema  # Already a string
+
+
+def parse_schema(schema: Union[str, Dict[str, Any]]) -> dict:
+    """
+    Parse a schema to a dictionary for inspection.
+
+    Accepts either:
+    - dict (from API): returned as-is
+    - string (from container file): parsed as JSON or YAML
+
+    Args:
+        schema: Schema as dict or string
+
+    Returns:
+        dict: Parsed schema dictionary
+
+    Raises:
+        ValueError: If string schema is neither valid JSON nor YAML
+    """
+    # If already a dict, return it
+    if isinstance(schema, dict):
+        return schema
+
+    # Try JSON first (faster, more strict)
+    try:
+        return json.loads(schema)
+    except json.JSONDecodeError:
+        pass
+
+    # Fall back to YAML (for container-extracted schemas)
+    try:
+        return yaml.safe_load(schema)
+    except yaml.YAMLError as e:
+        raise ValueError(f"Schema is neither valid JSON nor YAML: {e}")
+
+
+class ValidationError(Exception):
+    """Custom exception for validation errors with detailed messages"""
+    def __init__(self, message: str, errors: List[Dict[str, Any]]):
+        super().__init__(message)
+        self.errors = errors
+
+
+def should_skip_validation(schema: Union[str, Dict[str, Any]], target_class_name: str) -> bool:
+    """
+    Check if validation should be skipped for this schema.
+
+    Validation is skipped when:
+    - The target class has no attributes defined (permissive schema)
+    - The schema contains a 'skip_validation: true' marker
+
+    This allows models with dynamic output structures (like generative models)
+    to still have a schema file for documentation while skipping validation.
+
+    Args:
+        schema: Schema as dict (from API) or string (from container file)
+        target_class_name: Name of the class to check
+    """
+    try:
+        schema_dict = parse_schema(schema)
+
+        # Check for explicit skip marker
+        if schema_dict.get('skip_validation', False):
+            return True
+
+        # Check if target class has no attributes
+        classes = schema_dict.get('classes', {})
+        target_class = classes.get(target_class_name, {})
+        attributes = target_class.get('attributes', {})
+
+        # Skip if no attributes defined
+        if not attributes:
+            logger.info(f"Schema class '{target_class_name}' has no attributes - skipping validation")
+            return True
+
+        return False
+    except Exception:
+        # If we can't parse, don't skip - let validation handle errors
+        return False
+
+
+def validate_items(
+    items: List[Dict[str, Any]],
+    schema: Union[str, Dict[str, Any]],
+    target_class_name: str,
+    data_type: str = "input"
+) -> None:
+    """
+    Validate a list of data items against a LinkML schema.
+
+    Args:
+        items: List of dictionaries to validate
+        schema: LinkML schema as dict (from API) or string (from container file)
+        target_class_name: Class name in schema to validate against
+        data_type: "input" or "output" for error messages
+
+    Raises:
+        ValidationError: If any items fail validation, with detailed error info
+    """
+    if not schema:
+        # Should never happen - schemas are required
+        raise ValueError(f"Schema is required for {data_type} validation")
+
+    # Check if validation should be skipped (permissive schema)
+    if should_skip_validation(schema, target_class_name):
+        logger.info(f"Skipping {data_type} validation (permissive schema)")
+        return
+
+    validation_errors = []
+
+    # Normalize schema to string for LinkML (which requires a file path)
+    schema_str = normalize_schema_to_string(schema)
+
+    # Write schema to a temporary file (linkml.validator.validate requires a file path)
+    # LinkML accepts YAML files, but JSON is valid YAML, so we write as .yaml regardless
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as schema_file:
+        schema_file.write(schema_str)
+        schema_path = schema_file.name
+
+    try:
+        for idx, item in enumerate(items):
+            try:
+                # validate() takes: instance (dict), schema (file path), target_class (str)
+                report = validate(item, schema_path, target_class_name)
+
+                # Check if validation passed
+                if report.results:
+                    # Validation failed for this item
+                    error_messages = [result.message for result in report.results]
+                    validation_errors.append({
+                        "item_index": idx,
+                        "item": item,
+                        "errors": error_messages
+                    })
+
+            except Exception as e:
+                # Schema parsing or validation error
+                validation_errors.append({
+                    "item_index": idx,
+                    "item": item,
+                    "errors": [f"Validation exception: {str(e)}"]
+                })
+    finally:
+        # Clean up the temporary file
+        os.unlink(schema_path)
+
+    if validation_errors:
+        # Format a comprehensive error message
+        error_summary = f"{len(validation_errors)} of {len(items)} {data_type} items failed validation:\n"
+        for err in validation_errors[:5]:  # Show first 5 errors
+            error_summary += f"\n  Item {err['item_index']}:\n"
+            for msg in err['errors'][:3]:  # Show first 3 messages per item
+                error_summary += f"    - {msg}\n"
+
+        if len(validation_errors) > 5:
+            error_summary += f"\n  ... and {len(validation_errors) - 5} more items with errors"
+
+        raise ValidationError(error_summary, validation_errors)
+
+
+def extract_target_class(schema: Union[str, Dict[str, Any]]) -> str:
+    """
+    Extract the target class name from a LinkML schema.
+
+    Assumes the schema has exactly one class definition, which is typical
+    for simple input/output schemas.
+
+    Args:
+        schema: LinkML schema as dict (from API) or string (from container file)
+
+    Returns:
+        str: The class name to use for validation
+
+    Raises:
+        ValueError: If schema is invalid or has multiple classes
+    """
+    try:
+        schema_dict = parse_schema(schema)
+
+        if 'classes' not in schema_dict:
+            raise ValueError("Schema does not contain 'classes' section")
+
+        classes = schema_dict['classes']
+
+        if len(classes) == 0:
+            raise ValueError("Schema has no class definitions")
+
+        if len(classes) > 1:
+            # Multiple classes - use first one and warn
+            class_name = list(classes.keys())[0]
+            logger.warning(f"Schema has multiple classes, using first one: {class_name}")
+            return class_name
+
+        # Single class - return it
+        return list(classes.keys())[0]
+
+    except ValueError:
+        # Re-raise ValueError from parse_schema
+        raise
+    except Exception as e:
+        raise ValueError(f"Failed to parse schema: {e}")

--- a/app/model_server/model_server/validation.py
+++ b/app/model_server/model_server/validation.py
@@ -15,7 +15,6 @@ from typing import List, Dict, Any, Union, Optional, Tuple
 import yaml
 import requests
 import shutil
-import time
 from linkml.validator import validate
 from oaklib import get_adapter
 from oaklib.interfaces import OboGraphInterface
@@ -24,11 +23,8 @@ logger = logging.getLogger(__name__)
 
 _OAK_ADAPTER_CACHE: Dict[str, OboGraphInterface] = {}
 _LABEL_CACHE: Dict[str, Optional[str]] = {}
-_ONTOLOGY_FILE_CACHE: Dict[str, str] = {}
-_ONTOLOGY_FILE_META: Dict[str, Dict[str, Any]] = {}
 
 _ONTOLOGY_MAX_BYTES = int(os.getenv("MODEL_SERVER_ONTOLOGY_MAX_BYTES", str(300 * 1024 * 1024)))
-_ONTOLOGY_CACHE_MAX_BYTES = int(os.getenv("MODEL_SERVER_ONTOLOGY_CACHE_MAX_BYTES", str(1024 * 1024 * 1024)))
 _ONTOLOGY_TMP_DIR = os.getenv("MODEL_SERVER_ONTOLOGY_TMP_DIR", "/tmp")
 
 
@@ -161,41 +157,47 @@ def _expand_reachable_from_expression(expr: Dict[str, Any]) -> Dict[str, Dict[st
     include_self = bool(expr.get("include_self", expr.get("reflexive", False)))
     is_direct = bool(expr.get("is_direct", False))
 
-    source_ontology = _resolve_source_ontology(source_ontology)
-    adapter = _get_adapter(source_ontology)
+    resolved_source, temp_path = _resolve_source_ontology(source_ontology)
+    adapter = _get_adapter(resolved_source)
 
     expanded: Dict[str, Dict[str, Any]] = {}
-    for node in source_nodes:
-        try:
-            if is_direct and hasattr(adapter, "children"):
-                descendants = adapter.children(node, predicates=predicates)
-            else:
-                descendants = adapter.descendants(node, predicates=predicates)
-        except Exception as e:
-            raise ValueError(f"Failed to expand reachable_from for {node}: {e}")
+    try:
+        for node in source_nodes:
+            try:
+                if is_direct and hasattr(adapter, "children"):
+                    descendants = adapter.children(node, predicates=predicates)
+                else:
+                    descendants = adapter.descendants(node, predicates=predicates)
+            except Exception as e:
+                raise ValueError(f"Failed to expand reachable_from for {node}: {e}")
 
-        term_set = set(descendants or [])
-        if include_self:
-            term_set.add(node)
+            term_set = set(descendants or [])
+            if include_self:
+                term_set.add(node)
 
-        for term in term_set:
-            term_label = _get_label(adapter, term)
-            entry = {"meaning": term, "text": term}
-            if term_label and term_label != term:
-                entry["description"] = term_label
-            expanded[term] = entry
+            for term in term_set:
+                term_label = _get_label(adapter, term)
+                entry = {"meaning": term, "text": term}
+                if term_label and term_label != term:
+                    entry["description"] = term_label
+                expanded[term] = entry
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            try:
+                os.unlink(temp_path)
+            except Exception:
+                pass
 
     return expanded
 
 
-def _resolve_source_ontology(source_ontology: str) -> str:
+def _resolve_source_ontology(source_ontology: str) -> Tuple[str, Optional[str]]:
     if source_ontology.startswith("http://") or source_ontology.startswith("https://"):
-        cached_path = _ONTOLOGY_FILE_CACHE.get(source_ontology)
-        if cached_path and os.path.exists(cached_path):
-            _touch_ontology_cache(source_ontology)
-            return f"simpleobo:{cached_path}"
-
-        _ensure_ontology_cache_budget(0)
+        if not source_ontology.lower().endswith(".obo"):
+            logger.warning(
+                "Non-OBO ontology URL provided (%s). Prefer .obo for smaller downloads.",
+                source_ontology,
+            )
 
         try:
             response = requests.get(source_ontology, timeout=60, stream=True)
@@ -244,62 +246,13 @@ def _resolve_source_ontology(source_ontology: str) -> str:
                 f.write(chunk)
             temp_path = f.name
 
-        _ensure_ontology_cache_budget(total_bytes)
-
-        _ONTOLOGY_FILE_CACHE[source_ontology] = temp_path
-        _ONTOLOGY_FILE_META[source_ontology] = {
-            "path": temp_path,
-            "size": total_bytes,
-            "last_access": time.time(),
-        }
-        return f"simpleobo:{temp_path}"
+        return f"simpleobo:{temp_path}", temp_path
 
     if source_ontology.startswith("file:"):
         local_path = source_ontology[len("file:"):]
-        return f"simpleobo:{local_path}"
+        return f"simpleobo:{local_path}", None
 
-    return source_ontology
-
-
-def _touch_ontology_cache(source_ontology: str) -> None:
-    meta = _ONTOLOGY_FILE_META.get(source_ontology)
-    if meta:
-        meta["last_access"] = time.time()
-
-
-def _ensure_ontology_cache_budget(incoming_size: int) -> None:
-    if _ONTOLOGY_CACHE_MAX_BYTES <= 0:
-        return
-
-    total_size = sum(meta.get("size", 0) for meta in _ONTOLOGY_FILE_META.values())
-    if total_size + incoming_size <= _ONTOLOGY_CACHE_MAX_BYTES:
-        return
-
-    # Evict least recently used files until within budget
-    candidates = sorted(
-        _ONTOLOGY_FILE_META.items(),
-        key=lambda item: item[1].get("last_access", 0),
-    )
-    for url, meta in candidates:
-        path = meta.get("path")
-        size = meta.get("size", 0)
-        if path and os.path.exists(path):
-            try:
-                os.unlink(path)
-            except Exception:
-                pass
-        _ONTOLOGY_FILE_META.pop(url, None)
-        _ONTOLOGY_FILE_CACHE.pop(url, None)
-        total_size -= size
-        if total_size + incoming_size <= _ONTOLOGY_CACHE_MAX_BYTES:
-            break
-
-    if total_size + incoming_size > _ONTOLOGY_CACHE_MAX_BYTES:
-        raise ValueError(
-            f"Ontology cache budget exceeded. "
-            f"Current cache size {total_size} bytes, incoming {incoming_size} bytes, "
-            f"max {_ONTOLOGY_CACHE_MAX_BYTES} bytes."
-        )
+    return source_ontology, None
 
 
 def _collect_reachable_from(enum_def: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/app/model_server/model_server/validation.py
+++ b/app/model_server/model_server/validation.py
@@ -13,6 +13,9 @@ import os
 import json
 from typing import List, Dict, Any, Union, Optional, Tuple
 import yaml
+import requests
+import shutil
+import time
 from linkml.validator import validate
 from oaklib import get_adapter
 from oaklib.interfaces import OboGraphInterface
@@ -21,6 +24,12 @@ logger = logging.getLogger(__name__)
 
 _OAK_ADAPTER_CACHE: Dict[str, OboGraphInterface] = {}
 _LABEL_CACHE: Dict[str, Optional[str]] = {}
+_ONTOLOGY_FILE_CACHE: Dict[str, str] = {}
+_ONTOLOGY_FILE_META: Dict[str, Dict[str, Any]] = {}
+
+_ONTOLOGY_MAX_BYTES = int(os.getenv("MODEL_SERVER_ONTOLOGY_MAX_BYTES", str(300 * 1024 * 1024)))
+_ONTOLOGY_CACHE_MAX_BYTES = int(os.getenv("MODEL_SERVER_ONTOLOGY_CACHE_MAX_BYTES", str(1024 * 1024 * 1024)))
+_ONTOLOGY_TMP_DIR = os.getenv("MODEL_SERVER_ONTOLOGY_TMP_DIR", "/tmp")
 
 
 def normalize_schema_to_string(schema: Union[str, Dict[str, Any], None]) -> Optional[str]:
@@ -96,9 +105,26 @@ def _as_list(value: Any) -> List[Any]:
 def _normalize_permissible_values(pv: Any) -> Dict[str, Dict[str, Any]]:
     if pv is None:
         return {}
-    if isinstance(pv, dict):
-        return pv
-    raise ValueError("permissible_values must be a dict if provided")
+    if not isinstance(pv, dict):
+        raise ValueError("permissible_values must be a dict if provided")
+
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for key, value in pv.items():
+        if value is None:
+            normalized[key] = {"text": key, "meaning": key}
+            continue
+        if not isinstance(value, dict):
+            raise ValueError("permissible_values entries must be objects when provided")
+
+        entry = dict(value)
+        entry.setdefault("meaning", key)
+        if entry.get("text") != key:
+            if entry.get("description") is None and entry.get("text") not in (None, key):
+                entry["description"] = entry.get("text")
+            entry["text"] = key
+        normalized[key] = entry
+
+    return normalized
 
 
 def _get_adapter(source_ontology: str) -> OboGraphInterface:
@@ -135,6 +161,7 @@ def _expand_reachable_from_expression(expr: Dict[str, Any]) -> Dict[str, Dict[st
     include_self = bool(expr.get("include_self", expr.get("reflexive", False)))
     is_direct = bool(expr.get("is_direct", False))
 
+    source_ontology = _resolve_source_ontology(source_ontology)
     adapter = _get_adapter(source_ontology)
 
     expanded: Dict[str, Dict[str, Any]] = {}
@@ -153,12 +180,126 @@ def _expand_reachable_from_expression(expr: Dict[str, Any]) -> Dict[str, Dict[st
 
         for term in term_set:
             term_label = _get_label(adapter, term)
-            entry = {"meaning": term}
-            if term_label:
-                entry["text"] = term_label
+            entry = {"meaning": term, "text": term}
+            if term_label and term_label != term:
+                entry["description"] = term_label
             expanded[term] = entry
 
     return expanded
+
+
+def _resolve_source_ontology(source_ontology: str) -> str:
+    if source_ontology.startswith("http://") or source_ontology.startswith("https://"):
+        cached_path = _ONTOLOGY_FILE_CACHE.get(source_ontology)
+        if cached_path and os.path.exists(cached_path):
+            _touch_ontology_cache(source_ontology)
+            return f"simpleobo:{cached_path}"
+
+        _ensure_ontology_cache_budget(0)
+
+        try:
+            response = requests.get(source_ontology, timeout=60, stream=True)
+            response.raise_for_status()
+        except Exception as e:
+            raise ValueError(f"Failed to download ontology from {source_ontology}: {e}")
+
+        content_length = response.headers.get("Content-Length")
+        if content_length:
+            try:
+                content_length_int = int(content_length)
+            except ValueError:
+                content_length_int = None
+            if content_length_int and content_length_int > _ONTOLOGY_MAX_BYTES:
+                raise ValueError(
+                    f"Ontology file is too large ({content_length_int} bytes). "
+                    f"Max allowed is {_ONTOLOGY_MAX_BYTES} bytes."
+                )
+
+        expected_size = None
+        if content_length:
+            try:
+                expected_size = int(content_length)
+            except ValueError:
+                expected_size = None
+        size_check = expected_size or _ONTOLOGY_MAX_BYTES
+        free_space = shutil.disk_usage(_ONTOLOGY_TMP_DIR).free
+        if free_space < size_check:
+            raise ValueError(
+                f"Not enough free space in {_ONTOLOGY_TMP_DIR} for ontology download. "
+                f"Free {free_space} bytes, need at least {size_check} bytes."
+            )
+
+        total_bytes = 0
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".obo", delete=False, dir=_ONTOLOGY_TMP_DIR) as f:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if not chunk:
+                    continue
+                total_bytes += len(chunk)
+                if total_bytes > _ONTOLOGY_MAX_BYTES:
+                    f.close()
+                    os.unlink(f.name)
+                    raise ValueError(
+                        f"Ontology file exceeded max size {_ONTOLOGY_MAX_BYTES} bytes while downloading."
+                    )
+                f.write(chunk)
+            temp_path = f.name
+
+        _ensure_ontology_cache_budget(total_bytes)
+
+        _ONTOLOGY_FILE_CACHE[source_ontology] = temp_path
+        _ONTOLOGY_FILE_META[source_ontology] = {
+            "path": temp_path,
+            "size": total_bytes,
+            "last_access": time.time(),
+        }
+        return f"simpleobo:{temp_path}"
+
+    if source_ontology.startswith("file:"):
+        local_path = source_ontology[len("file:"):]
+        return f"simpleobo:{local_path}"
+
+    return source_ontology
+
+
+def _touch_ontology_cache(source_ontology: str) -> None:
+    meta = _ONTOLOGY_FILE_META.get(source_ontology)
+    if meta:
+        meta["last_access"] = time.time()
+
+
+def _ensure_ontology_cache_budget(incoming_size: int) -> None:
+    if _ONTOLOGY_CACHE_MAX_BYTES <= 0:
+        return
+
+    total_size = sum(meta.get("size", 0) for meta in _ONTOLOGY_FILE_META.values())
+    if total_size + incoming_size <= _ONTOLOGY_CACHE_MAX_BYTES:
+        return
+
+    # Evict least recently used files until within budget
+    candidates = sorted(
+        _ONTOLOGY_FILE_META.items(),
+        key=lambda item: item[1].get("last_access", 0),
+    )
+    for url, meta in candidates:
+        path = meta.get("path")
+        size = meta.get("size", 0)
+        if path and os.path.exists(path):
+            try:
+                os.unlink(path)
+            except Exception:
+                pass
+        _ONTOLOGY_FILE_META.pop(url, None)
+        _ONTOLOGY_FILE_CACHE.pop(url, None)
+        total_size -= size
+        if total_size + incoming_size <= _ONTOLOGY_CACHE_MAX_BYTES:
+            break
+
+    if total_size + incoming_size > _ONTOLOGY_CACHE_MAX_BYTES:
+        raise ValueError(
+            f"Ontology cache budget exceeded. "
+            f"Current cache size {total_size} bytes, incoming {incoming_size} bytes, "
+            f"max {_ONTOLOGY_CACHE_MAX_BYTES} bytes."
+        )
 
 
 def _collect_reachable_from(enum_def: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/app/model_server/model_server/validation.py
+++ b/app/model_server/model_server/validation.py
@@ -11,11 +11,16 @@ import logging
 import tempfile
 import os
 import json
-from typing import List, Dict, Any, Union, Optional
+from typing import List, Dict, Any, Union, Optional, Tuple
 import yaml
 from linkml.validator import validate
+from oaklib import get_adapter
+from oaklib.interfaces import OboGraphInterface
 
 logger = logging.getLogger(__name__)
+
+_OAK_ADAPTER_CACHE: Dict[str, OboGraphInterface] = {}
+_LABEL_CACHE: Dict[str, Optional[str]] = {}
 
 
 def normalize_schema_to_string(schema: Union[str, Dict[str, Any], None]) -> Optional[str]:
@@ -78,6 +83,184 @@ class ValidationError(Exception):
     def __init__(self, message: str, errors: List[Dict[str, Any]]):
         super().__init__(message)
         self.errors = errors
+
+
+def _as_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _normalize_permissible_values(pv: Any) -> Dict[str, Dict[str, Any]]:
+    if pv is None:
+        return {}
+    if isinstance(pv, dict):
+        return pv
+    raise ValueError("permissible_values must be a dict if provided")
+
+
+def _get_adapter(source_ontology: str) -> OboGraphInterface:
+    adapter = _OAK_ADAPTER_CACHE.get(source_ontology)
+    if adapter is not None:
+        return adapter
+    adapter = get_adapter(source_ontology)
+    if not isinstance(adapter, OboGraphInterface):
+        raise ValueError(f"Ontology adapter for '{source_ontology}' does not support graph traversal")
+    _OAK_ADAPTER_CACHE[source_ontology] = adapter
+    return adapter
+
+
+def _get_label(adapter: OboGraphInterface, curie: str) -> Optional[str]:
+    cached = _LABEL_CACHE.get(curie)
+    if cached is not None or curie in _LABEL_CACHE:
+        return cached
+    try:
+        label = adapter.label(curie)
+    except Exception:
+        label = None
+    _LABEL_CACHE[curie] = label
+    return label
+
+
+def _expand_reachable_from_expression(expr: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    source_ontology = expr.get("source_ontology")
+    source_nodes = _as_list(expr.get("source_nodes"))
+    if not source_ontology or not source_nodes:
+        raise ValueError("reachable_from requires 'source_ontology' and non-empty 'source_nodes'")
+
+    relationship_types = _as_list(expr.get("relationship_types"))
+    predicates = relationship_types if relationship_types else None
+    include_self = bool(expr.get("include_self", expr.get("reflexive", False)))
+    is_direct = bool(expr.get("is_direct", False))
+
+    adapter = _get_adapter(source_ontology)
+
+    expanded: Dict[str, Dict[str, Any]] = {}
+    for node in source_nodes:
+        try:
+            if is_direct and hasattr(adapter, "children"):
+                descendants = adapter.children(node, predicates=predicates)
+            else:
+                descendants = adapter.descendants(node, predicates=predicates)
+        except Exception as e:
+            raise ValueError(f"Failed to expand reachable_from for {node}: {e}")
+
+        term_set = set(descendants or [])
+        if include_self:
+            term_set.add(node)
+
+        for term in term_set:
+            term_label = _get_label(adapter, term)
+            entry = {"meaning": term}
+            if term_label:
+                entry["text"] = term_label
+            expanded[term] = entry
+
+    return expanded
+
+
+def _collect_reachable_from(enum_def: Dict[str, Any]) -> List[Dict[str, Any]]:
+    exprs: List[Dict[str, Any]] = []
+
+    def add_expr(value: Any) -> None:
+        for expr in _as_list(value):
+            if not isinstance(expr, dict):
+                raise ValueError("reachable_from entries must be objects")
+            exprs.append(expr)
+
+    add_expr(enum_def.get("reachable_from"))
+
+    for key in ("include", "minus"):
+        for entry in _as_list(enum_def.get(key)):
+            if isinstance(entry, dict) and "reachable_from" in entry:
+                add_expr(entry.get("reachable_from"))
+
+    return exprs
+
+
+def schema_has_reachable_from(schema_dict: Dict[str, Any]) -> bool:
+    enums = schema_dict.get("enums", {}) or {}
+    for enum_def in enums.values():
+        if not isinstance(enum_def, dict):
+            continue
+        if _collect_reachable_from(enum_def):
+            return True
+    return False
+
+
+def expand_reachable_from_schema(schema: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
+    schema_dict = parse_schema(schema)
+    enums = schema_dict.get("enums", {}) or {}
+
+    for enum_name, enum_def in enums.items():
+        if not isinstance(enum_def, dict):
+            raise ValueError(f"Enum definition for {enum_name} must be an object")
+
+        reachable_exprs = _collect_reachable_from(enum_def)
+        if not reachable_exprs:
+            continue
+
+        existing_pv = _normalize_permissible_values(enum_def.get("permissible_values"))
+        expanded_pv: Dict[str, Dict[str, Any]] = {}
+
+        for expr in reachable_exprs:
+            expanded_pv.update(_expand_reachable_from_expression(expr))
+
+        # Include permissible_values from "include" entries
+        for include_entry in _as_list(enum_def.get("include")):
+            if isinstance(include_entry, dict) and "permissible_values" in include_entry:
+                expanded_pv.update(_normalize_permissible_values(include_entry.get("permissible_values")))
+
+        # Merge expanded values, then re-apply explicit values so they win
+        merged_pv = dict(expanded_pv)
+        merged_pv.update(existing_pv)
+
+        # Apply "minus" entries after merge
+        for minus_entry in _as_list(enum_def.get("minus")):
+            if not isinstance(minus_entry, dict):
+                continue
+            if "permissible_values" in minus_entry:
+                for key in _normalize_permissible_values(minus_entry.get("permissible_values")).keys():
+                    merged_pv.pop(key, None)
+            if "reachable_from" in minus_entry:
+                for expr in _as_list(minus_entry.get("reachable_from")):
+                    if not isinstance(expr, dict):
+                        raise ValueError("reachable_from entries must be objects")
+                    for key in _expand_reachable_from_expression(expr).keys():
+                        merged_pv.pop(key, None)
+
+        enum_def["permissible_values"] = merged_pv
+        enum_def.pop("reachable_from", None)
+
+        for key in ("include", "minus"):
+            cleaned_entries = []
+            for entry in _as_list(enum_def.get(key)):
+                if isinstance(entry, dict) and "reachable_from" in entry:
+                    entry = dict(entry)
+                    entry.pop("reachable_from", None)
+                    if not entry:
+                        continue
+                cleaned_entries.append(entry)
+            if cleaned_entries:
+                enum_def[key] = cleaned_entries
+            else:
+                enum_def.pop(key, None)
+
+    return schema_dict
+
+
+def expand_and_normalize_schema(schema: Union[str, Dict[str, Any], None]) -> Tuple[Optional[str], Optional[str]]:
+    if schema is None:
+        return None, None
+    original_str = normalize_schema_to_string(schema)
+    schema_dict = parse_schema(schema)
+    if not schema_has_reachable_from(schema_dict):
+        return original_str, original_str
+    expanded_dict = expand_reachable_from_schema(schema_dict)
+    expanded_str = json.dumps(expanded_dict)
+    return original_str, expanded_str
 
 
 def should_skip_validation(schema: Union[str, Dict[str, Any]], target_class_name: str) -> bool:

--- a/app/model_server/models/coxcopdmodel/Dockerfile
+++ b/app/model_server/models/coxcopdmodel/Dockerfile
@@ -38,6 +38,7 @@ COPY predict ./
 # Copy metadata files for container-based registration
 COPY README.md ./
 COPY examples.json ./
+COPY input_schema.yaml output_schema.yaml ./
 
 # Make the 'predict' shell script executable
 RUN chmod +x predict

--- a/app/model_server/models/coxcopdmodel/input_schema.yaml
+++ b/app/model_server/models/coxcopdmodel/input_schema.yaml
@@ -1,0 +1,74 @@
+# LinkML schema for CoxCOPDModel input validation
+# This schema defines the structure of ONE input item.
+# The model_server validates each item in the input array separately.
+
+id: https://w3id.org/charmtwinsights/coxcopdmodel/input
+name: coxcopd_input
+description: Input schema for Cox COPD survival model
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+# Enumerations for categorical fields
+enums:
+  EthnicityEnum:
+    description: Patient ethnicity categories
+    permissible_values:
+      Not Hispanic or Latino:
+        description: Not Hispanic or Latino
+      Hispanic or Latino:
+        description: Hispanic or Latino
+
+  SexAtBirthEnum:
+    description: Biological sex at birth
+    permissible_values:
+      Female:
+        description: Female
+      Male:
+        description: Male
+
+classes:
+  CoxCOPDInputItem:
+    description: Patient data for COPD risk prediction
+    attributes:
+      ethnicity:
+        description: Patient ethnicity
+        range: EthnicityEnum
+        required: true
+      sex_at_birth:
+        description: Biological sex at birth
+        range: SexAtBirthEnum
+        required: true
+      obesity:
+        description: Obesity status (0.0=no, 1.0=yes)
+        range: float
+        required: true
+      diabetes:
+        description: Diabetes status (0.0=no, 1.0=yes)
+        range: float
+        required: true
+      cardiovascular_disease:
+        description: Cardiovascular disease status (0.0=no, 1.0=yes)
+        range: float
+        required: true
+      smoking_status:
+        description: Smoking status (0.0=no, 1.0=yes)
+        range: float
+        required: true
+      alcohol_use:
+        description: Alcohol use (0.0=no, 1.0=yes)
+        range: float
+        required: true
+      bmi:
+        description: Body Mass Index
+        range: float
+        required: true
+      age_at_time_0:
+        description: Patient age at baseline
+        range: float
+        required: true

--- a/app/model_server/models/coxcopdmodel/output_schema.yaml
+++ b/app/model_server/models/coxcopdmodel/output_schema.yaml
@@ -1,0 +1,28 @@
+# LinkML schema for CoxCOPDModel output validation
+# This schema defines the structure of ONE output item.
+# The model_server validates each item in the output array separately.
+
+id: https://w3id.org/charmtwinsights/coxcopdmodel/output
+name: coxcopd_output
+description: Output schema for Cox COPD survival model
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  CoxCOPDOutputItem:
+    description: COPD risk and survival predictions
+    attributes:
+      partial_hazard:
+        description: Partial hazard ratio for COPD risk (can be null for edge cases)
+        range: float
+        required: false
+      survival_probability_5_years:
+        description: Probability of survival at 5 years
+        range: float
+        required: false

--- a/app/model_server/models/coxcopdmodel/register_model_image.sh
+++ b/app/model_server/models/coxcopdmodel/register_model_image.sh
@@ -2,12 +2,37 @@
 
 APP_PORT=${APP_PORT:-8000}
 
-echo -e "Registering Cox PH COPD model to the model server (using container-based metadata)...\n"
+echo -e "Registering Cox PH COPD model to the model server...\n"
 curl -X POST http://localhost:$APP_PORT/modeling/models \
   -H "Content-Type: application/json" \
   -d '{
     "image": "coxcopdmodel:latest",
     "title": "Cox PH Model for COPD Prediction",
     "short_description": "A survival model to predict risk and survival probability for COPD based on demographics and comorbidities.",
-    "authors": "Lakshmi Anandan"
+    "authors": "Lakshmi Anandan",
+    "examples": [
+      {
+        "ethnicity": "Not Hispanic or Latino",
+        "sex_at_birth": "Female",
+        "obesity": 0.0,
+        "diabetes": 0.0,
+        "cardiovascular_disease": 0.0,
+        "smoking_status": 0.0,
+        "alcohol_use": 0.0,
+        "bmi": 25.0,
+        "age_at_time_0": 50.0
+      },
+      {
+        "ethnicity": "Hispanic or Latino",
+        "sex_at_birth": "Male",
+        "obesity": 1.0,
+        "diabetes": 1.0,
+        "cardiovascular_disease": 1.0,
+        "smoking_status": 1.0,
+        "alcohol_use": 1.0,
+        "bmi": 32.0,
+        "age_at_time_0": 65.0
+      }
+    ],
+    "readme": "## CoxCOPDModel\\nA Cox Proportional Hazards model for predicting COPD risk and survival probability based on patient demographics and comorbidities."
   }'

--- a/app/model_server/models/dpcgansmodel/Dockerfile
+++ b/app/model_server/models/dpcgansmodel/Dockerfile
@@ -8,6 +8,7 @@ COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-interaction --no-root
 
 COPY dpcgan_model.pkl predict.py predict ./
+COPY input_schema.yaml output_schema.yaml ./
 
 RUN chmod +x predict
 

--- a/app/model_server/models/dpcgansmodel/input_schema.yaml
+++ b/app/model_server/models/dpcgansmodel/input_schema.yaml
@@ -1,0 +1,40 @@
+# LinkML schema for DPCGANSModel input validation
+# This schema defines the structure of ONE input item.
+# The model_server validates each item in the input array separately.
+
+id: https://w3id.org/charmtwinsights/dpcgansmodel/input
+name: dpcgans_input
+description: Input schema for DPCGANS synthetic data generation
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  DPCGANSInputItem:
+    description: Parameters for synthetic data generation
+    attributes:
+      num_rows:
+        description: Number of synthetic rows to generate
+        range: integer
+        required: true
+      max_retries:
+        description: Maximum retry attempts for sampling
+        range: integer
+        required: true
+      max_rows_multiplier:
+        description: Multiplier for maximum rows during sampling
+        range: integer
+        required: true
+      float_rtol:
+        description: Relative tolerance for float comparisons
+        range: float
+        required: true
+      graceful_reject_sampling:
+        description: Use graceful reject sampling
+        range: boolean
+        required: true

--- a/app/model_server/models/dpcgansmodel/output_schema.yaml
+++ b/app/model_server/models/dpcgansmodel/output_schema.yaml
@@ -1,0 +1,39 @@
+# LinkML schema for DPCGANSModel output validation
+#
+# This model generates synthetic tabular data with a DYNAMIC structure
+# that depends on the model's training data. The columns and types of
+# generated records cannot be known at schema definition time.
+#
+# OUTPUT VALIDATION IS SKIPPED for this model because:
+# - Generated data structure depends on training data
+# - Each output item contains a variable number of records
+# - Record fields vary based on the original dataset
+#
+# This schema exists to:
+# 1. Satisfy the schema requirement for model registration
+# 2. Document the expected output format
+# 3. Signal to the validator that output validation should be skipped
+#    (by having no attributes defined)
+
+id: https://w3id.org/charmtwinsights/dpcgansmodel/output
+name: dpcgans_output
+description: |
+  Output schema for DPCGANS synthetic data generation.
+  Output validation is skipped due to dynamic structure.
+  Each output item contains a 'synthetic_data' array with generated records.
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  DPCGANSOutputItem:
+    description: |
+      A synthetic dataset generation result. The structure is dynamic
+      and depends on the model's training data. Output validation is
+      skipped for this schema (no attributes defined).
+    # No attributes - validation will be skipped

--- a/app/model_server/models/dpcgansmodel/predict.py
+++ b/app/model_server/models/dpcgansmodel/predict.py
@@ -49,7 +49,8 @@ def main():
             yhat = model.sample(**x)
             # result is a df; we need to convert NaNs to Nones so we can serialize to json properly
             yhat = yhat.replace({np.nan: None})
-            res.append(yhat.to_dict(orient="records"))
+            # Wrap in object for schema validation
+            res.append({"synthetic_data": yhat.to_dict(orient="records")})
 
         print(f"Successfully generated {len(res)} synthetic datasets", file=sys.stderr)
 

--- a/app/model_server/models/irismodel/Dockerfile
+++ b/app/model_server/models/irismodel/Dockerfile
@@ -9,6 +9,8 @@ RUN poetry install --no-interaction --no-root
 
 COPY iris_model ./iris_model
 COPY predict.py predict ./
+# Using JSON schema files to test JSON schema support
+COPY input_schema.json output_schema.json ./
 
 RUN chmod +x predict
 

--- a/app/model_server/models/irismodel/input_schema.json
+++ b/app/model_server/models/irismodel/input_schema.json
@@ -1,0 +1,37 @@
+{
+  "id": "https://w3id.org/charmtwinsights/irismodel/input",
+  "name": "iris_input",
+  "description": "Input schema for Iris classification model",
+  "prefixes": {
+    "linkml": "https://w3id.org/linkml/"
+  },
+  "imports": ["linkml:types"],
+  "default_range": "string",
+  "classes": {
+    "IrisInputItem": {
+      "description": "Iris flower measurements for classification",
+      "attributes": {
+        "sepal_length_cm": {
+          "description": "Sepal length in centimeters",
+          "range": "float",
+          "required": true
+        },
+        "sepal_width_cm": {
+          "description": "Sepal width in centimeters",
+          "range": "float",
+          "required": true
+        },
+        "petal_length_cm": {
+          "description": "Petal length in centimeters",
+          "range": "float",
+          "required": true
+        },
+        "petal_width_cm": {
+          "description": "Petal width in centimeters",
+          "range": "float",
+          "required": true
+        }
+      }
+    }
+  }
+}

--- a/app/model_server/models/irismodel/input_schema.yaml
+++ b/app/model_server/models/irismodel/input_schema.yaml
@@ -1,0 +1,36 @@
+# LinkML schema for IrisModel input validation
+# This schema defines the structure of ONE input item.
+# The model_server validates each item in the input array separately.
+
+id: https://w3id.org/charmtwinsights/irismodel/input
+name: iris_input
+description: Input schema for Iris classification model
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  IrisInputItem:
+    description: Iris flower measurements for classification
+    attributes:
+      sepal_length_cm:
+        description: Sepal length in centimeters
+        range: float
+        required: true
+      sepal_width_cm:
+        description: Sepal width in centimeters
+        range: float
+        required: true
+      petal_length_cm:
+        description: Petal length in centimeters
+        range: float
+        required: true
+      petal_width_cm:
+        description: Petal width in centimeters
+        range: float
+        required: true

--- a/app/model_server/models/irismodel/model_metadata.json
+++ b/app/model_server/models/irismodel/model_metadata.json
@@ -5,17 +5,17 @@
   "authors": "John Doe, Jane Smith",
   "examples": [
     {
-      "sepal length (cm)": 5.1,
-      "sepal width (cm)": 3.5,
-      "petal length (cm)": 1.4,
-      "petal width (cm)": 0.2
+      "sepal_length_cm": 5.1,
+      "sepal_width_cm": 3.5,
+      "petal_length_cm": 1.4,
+      "petal_width_cm": 0.2
     },
     {
-      "sepal length (cm)": 7.0,
-      "sepal width (cm)": 3.2,
-      "petal length (cm)": 4.7,
-      "petal width (cm)": 1.4
-    }    
+      "sepal_length_cm": 7.0,
+      "sepal_width_cm": 3.2,
+      "petal_length_cm": 4.7,
+      "petal_width_cm": 1.4
+    }
   ],
   "readme": "## IrisModel\nThis model predicts the species of iris flowers based on their sepal and petal dimensions. It is trained on the classic Iris dataset and can classify iris species into three categories: Setosa, Versicolor, and Virginica."
 }

--- a/app/model_server/models/irismodel/output_schema.json
+++ b/app/model_server/models/irismodel/output_schema.json
@@ -1,0 +1,22 @@
+{
+  "id": "https://w3id.org/charmtwinsights/irismodel/output",
+  "name": "iris_output",
+  "description": "Output schema for Iris classification model",
+  "prefixes": {
+    "linkml": "https://w3id.org/linkml/"
+  },
+  "imports": ["linkml:types"],
+  "default_range": "string",
+  "classes": {
+    "IrisOutputItem": {
+      "description": "Iris species classification prediction",
+      "attributes": {
+        "prediction": {
+          "description": "Predicted species (0=setosa, 1=versicolor, 2=virginica)",
+          "range": "integer",
+          "required": true
+        }
+      }
+    }
+  }
+}

--- a/app/model_server/models/irismodel/output_schema.yaml
+++ b/app/model_server/models/irismodel/output_schema.yaml
@@ -1,0 +1,24 @@
+# LinkML schema for IrisModel output validation
+# This schema defines the structure of ONE output item.
+# The model_server validates each item in the output array separately.
+
+id: https://w3id.org/charmtwinsights/irismodel/output
+name: iris_output
+description: Output schema for Iris classification model
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  IrisOutputItem:
+    description: Iris species classification prediction
+    attributes:
+      prediction:
+        description: Predicted species (0=setosa, 1=versicolor, 2=virginica)
+        range: integer
+        required: true

--- a/app/model_server/models/irismodel/predict.py
+++ b/app/model_server/models/irismodel/predict.py
@@ -20,7 +20,16 @@ def main():
         # Load input features
         with open(input_file) as f:
             X = pd.read_json(f)
-        
+
+        # Rename columns from schema format to sklearn iris dataset format
+        column_mapping = {
+            'sepal_length_cm': 'sepal length (cm)',
+            'sepal_width_cm': 'sepal width (cm)',
+            'petal_length_cm': 'petal length (cm)',
+            'petal_width_cm': 'petal width (cm)'
+        }
+        X = X.rename(columns=column_mapping)
+
         print(f"Loaded {len(X)} samples for prediction", file=sys.stderr)
         
         # Load model
@@ -29,8 +38,9 @@ def main():
         
         # Make predictions
         preds = model.predict(X)
-        predictions = preds.tolist()
-        
+        # Output as list of objects with named fields for schema validation
+        predictions = [{"prediction": int(p)} for p in preds]
+
         print(f"Generated {len(predictions)} predictions", file=sys.stderr)
         
         # Output results

--- a/app/model_server/models/irismodel/register_model_image.sh
+++ b/app/model_server/models/irismodel/register_model_image.sh
@@ -12,17 +12,17 @@ curl -X POST "http://localhost:$APP_PORT/modeling/models" \
     "authors": "John Doe, Jane Smith",
     "examples": [
       {
-        "sepal length (cm)": 5.1,
-        "sepal width (cm)": 3.5,
-        "petal length (cm)": 1.4,
-        "petal width (cm)": 0.2
+        "sepal_length_cm": 5.1,
+        "sepal_width_cm": 3.5,
+        "petal_length_cm": 1.4,
+        "petal_width_cm": 0.2
       },
       {
-        "sepal length (cm)": 7.0,
-        "sepal width (cm)": 3.2,
-        "petal length (cm)": 4.7,
-        "petal width (cm)": 1.4
-      }    
+        "sepal_length_cm": 7.0,
+        "sepal_width_cm": 3.2,
+        "petal_length_cm": 4.7,
+        "petal_width_cm": 1.4
+      }
     ],
     "readme": "## IrisModel\nThis model predicts the species of iris flowers based on their sepal and petal dimensions. It is trained on the classic Iris dataset and can classify iris species into three categories: Setosa, Versicolor, and Virginica."
   }'

--- a/app/model_server/models/reachablefrommodel/Dockerfile
+++ b/app/model_server/models/reachablefrommodel/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY predict.py predict input_schema.yaml output_schema.yaml examples.json README.md ./
+
+RUN chmod +x predict

--- a/app/model_server/models/reachablefrommodel/README.md
+++ b/app/model_server/models/reachablefrommodel/README.md
@@ -1,0 +1,11 @@
+# ReachableFromModel
+
+This demo model exercises LinkML `reachable_from` enum expansion during registration.
+It accepts a biological sex term and age in years, then echoes a normalized output.
+
+The input schema uses the public PATO ontology (downloaded on demand):
+`http://purl.obolibrary.org/obo/pato.obo`
+
+The root term `PATO:0000047` (biological sex) has children like
+`PATO:0000383` (female) and `PATO:0000384` (male), so reachable_from expansion
+should permit those values.

--- a/app/model_server/models/reachablefrommodel/build_docker.sh
+++ b/app/model_server/models/reachablefrommodel/build_docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Usage: ./build_docker.sh [build args]
+# e.g. ./build_docker.sh --no-cache
+
+TAGS=(
+  "reachablefrommodel:latest"
+  "reachablefrommodel:0.1.0"
+)
+
+args="$@"
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+docker build $args ${TAGS[@]/#/-t } -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR"

--- a/app/model_server/models/reachablefrommodel/examples.json
+++ b/app/model_server/models/reachablefrommodel/examples.json
@@ -1,0 +1,6 @@
+[
+  {
+    "biological_sex": "PATO:0000383",
+    "age_years": 34
+  }
+]

--- a/app/model_server/models/reachablefrommodel/input_schema.yaml
+++ b/app/model_server/models/reachablefrommodel/input_schema.yaml
@@ -1,0 +1,34 @@
+id: https://example.org/reachablefrommodel/input
+name: ReachableFromModelInput
+description: Input schema demonstrating reachable_from expansion
+prefixes:
+  linkml: https://w3id.org/linkml/
+  PATO: http://purl.obolibrary.org/obo/PATO_
+  CHARM: https://example.org/charm/
+imports:
+  - linkml:types
+default_range: string
+
+enums:
+  BiologicalSexEnum:
+    description: Biological sex expanded from ontology
+    reachable_from:
+      source_ontology: "http://purl.obolibrary.org/obo/pato.obo"
+      source_nodes:
+        - "PATO:0000047"
+      include_self: true
+    permissible_values:
+      Unknown:
+        text: Unknown
+        meaning: CHARM:Unknown
+        description: Unknown/missing value
+
+classes:
+  InputRecord:
+    attributes:
+      biological_sex:
+        required: true
+        range: BiologicalSexEnum
+      age_years:
+        required: true
+        range: integer

--- a/app/model_server/models/reachablefrommodel/model_metadata.json
+++ b/app/model_server/models/reachablefrommodel/model_metadata.json
@@ -1,0 +1,13 @@
+{
+  "image": "reachablefrommodel:latest",
+  "title": "Reachable From Demo Model",
+  "short_description": "Demonstrates LinkML reachable_from enum expansion.",
+  "authors": "CHARMTwinsight Team",
+  "examples": [
+    {
+      "biological_sex": "PATO:0000383",
+      "age_years": 34
+    }
+  ],
+  "readme": "## ReachableFromModel\nThis demo model exercises LinkML reachable_from expansion during registration. The input schema uses the public PATO ontology at http://purl.obolibrary.org/obo/pato.obo."
+}

--- a/app/model_server/models/reachablefrommodel/output_schema.yaml
+++ b/app/model_server/models/reachablefrommodel/output_schema.yaml
@@ -1,0 +1,18 @@
+id: https://example.org/reachablefrommodel/output
+name: ReachableFromModelOutput
+description: Output schema for reachable_from demo
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+
+classes:
+  OutputRecord:
+    attributes:
+      normalized_sex:
+        required: true
+        range: string
+      is_adult:
+        required: true
+        range: boolean

--- a/app/model_server/models/reachablefrommodel/predict
+++ b/app/model_server/models/reachablefrommodel/predict
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 predict.py "$@"

--- a/app/model_server/models/reachablefrommodel/predict.py
+++ b/app/model_server/models/reachablefrommodel/predict.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+def main() -> int:
+    if len(sys.argv) not in (2, 3):
+        print("Usage: predict <input.json> [output.json]", file=sys.stderr)
+        return 1
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2] if len(sys.argv) == 3 else None
+
+    with open(input_file, "r") as f:
+        records = json.load(f)
+
+    outputs = []
+    for record in records:
+        age = record.get("age_years")
+        outputs.append({
+            "normalized_sex": record.get("biological_sex"),
+            "is_adult": bool(age is not None and age >= 18),
+        })
+
+    if output_file:
+        with open(output_file, "w") as f:
+            json.dump(outputs, f, indent=2)
+    else:
+        print(json.dumps(outputs))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/model_server/models/reachablefrommodel/register_model_image.sh
+++ b/app/model_server/models/reachablefrommodel/register_model_image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+APP_PORT=${APP_PORT:-8000}
+
+echo -e "\n\nPushing reachable-from demo model to the model server...\n"
+curl -X POST "http://localhost:$APP_PORT/modeling/models" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image": "reachablefrommodel:latest",
+    "title": "Reachable From Demo Model",
+    "short_description": "Demonstrates LinkML reachable_from enum expansion.",
+    "authors": "CHARMTwinsight Team",
+    "examples": [
+      {
+        "biological_sex": "PATO:0000383",
+        "age_years": 34
+      }
+    ],
+    "readme": "## ReachableFromModel\nThis demo model exercises LinkML reachable_from expansion during registration. The input schema uses the public PATO ontology at http://purl.obolibrary.org/obo/pato.obo."
+  }'
+
+echo -e "\n"

--- a/app/model_server/models/test_predict_models.sh
+++ b/app/model_server/models/test_predict_models.sh
@@ -5,7 +5,7 @@ APP_PORT=${APP_PORT:-8000}
 echo -e "Iris model prediction:\n"
 curl -X POST http://localhost:$APP_PORT/modeling/predict \
   -H "Content-Type: application/json" \
-  -d '{"image": "irismodel:latest", "input": [{"sepal length (cm)": 5.1, "sepal width (cm)": 3.5, "petal length (cm)": 1.4, "petal width (cm)": 0.2}, {"sepal length (cm)": 4.9, "sepal width (cm)": 3.0, "petal length (cm)": 1.4, "petal width (cm)": 0.2}]}'
+  -d '{"image": "irismodel:latest", "input": [{"sepal_length_cm": 5.1, "sepal_width_cm": 3.5, "petal_length_cm": 1.4, "petal_width_cm": 0.2}, {"sepal_length_cm": 4.9, "sepal_width_cm": 3.0, "petal_length_cm": 1.4, "petal_width_cm": 0.2}]}'
 
 echo -e "\n\nDPCGAN model prediction:\n"
 curl -X POST http://localhost:$APP_PORT/modeling/predict \

--- a/app/model_server/models/test_predict_models.sh
+++ b/app/model_server/models/test_predict_models.sh
@@ -56,3 +56,11 @@ curl -X POST http://localhost:$APP_PORT/modeling/predict \
 
 echo -e "\n\nPrediction test for coxcopdmodel sent."
 echo -e "\n"
+
+echo -e "\n\nReachableFromModel prediction:\n"
+curl -X POST http://localhost:$APP_PORT/modeling/predict \
+  -H "Content-Type: application/json" \
+  -d '{"image": "reachablefrommodel:latest", "input": [{"biological_sex": "PATO:0000383", "age_years": 34}]}'
+
+echo -e "\n\nPrediction test for reachablefrommodel sent."
+echo -e "\n"

--- a/app/model_server/models/test_validation.sh
+++ b/app/model_server/models/test_validation.sh
@@ -1,0 +1,419 @@
+#!/bin/bash
+
+# Test script for LinkML schema validation
+# Tests valid and invalid inputs for all built-in models
+# Tests model registration with API-provided JSON schema objects
+# Returns exit code 0 if all tests pass, 1 if any fail
+#
+# Schema Format Coverage:
+# - IrisModel: Uses JSON schema files (input_schema.json, output_schema.json)
+# - CoxCOPDModel: Uses YAML schema files (input_schema.yaml, output_schema.yaml)
+# - DPCGANSModel: Uses YAML schema files with permissive output
+# - API Registration: Tests JSON schema objects in request body (not escaped strings)
+
+APP_PORT=${APP_PORT:-8004}
+BASE_URL="http://localhost:$APP_PORT"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Test counters
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+# Helper function to run a test
+run_test() {
+    local test_name="$1"
+    local expected_status="$2"
+    local curl_data="$3"
+
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+
+    echo -e "${BLUE}Test $TOTAL_TESTS: $test_name${NC}"
+
+    # Make request and capture both response and HTTP status
+    response=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/predict" \
+        -H "Content-Type: application/json" \
+        -d "$curl_data")
+
+    # Extract HTTP status code (last line)
+    http_status=$(echo "$response" | tail -n 1)
+    # Extract response body (everything except last line)
+    response_body=$(echo "$response" | sed '$d')
+
+    # Check if status matches expected
+    if [ "$http_status" -eq "$expected_status" ]; then
+        echo -e "${GREEN}✓ PASS${NC} - Got expected status $http_status"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+
+        # Show response for debugging (truncated if too long)
+        if [ ${#response_body} -gt 200 ]; then
+            echo "Response: ${response_body:0:200}..."
+        else
+            echo "Response: $response_body"
+        fi
+    else
+        echo -e "${RED}✗ FAIL${NC} - Expected status $expected_status, got $http_status"
+        echo "Response: $response_body"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    fi
+
+    echo ""
+}
+
+# Print header
+echo -e "${YELLOW}======================================${NC}"
+echo -e "${YELLOW}LinkML Schema Validation Test Suite${NC}"
+echo -e "${YELLOW}======================================${NC}"
+echo ""
+
+# ====================
+# IrisModel Tests (JSON Schema Format)
+# ====================
+echo -e "${YELLOW}--- IrisModel Tests (JSON Schema) ---${NC}"
+echo ""
+
+run_test "IrisModel: Valid input" 200 '{
+    "image": "irismodel:latest",
+    "input": [{
+        "sepal_length_cm": 5.1,
+        "sepal_width_cm": 3.5,
+        "petal_length_cm": 1.4,
+        "petal_width_cm": 0.2
+    }]
+}'
+
+run_test "IrisModel: Missing required field (petal_width_cm)" 400 '{
+    "image": "irismodel:latest",
+    "input": [{
+        "sepal_length_cm": 5.1,
+        "sepal_width_cm": 3.5,
+        "petal_length_cm": 1.4
+    }]
+}'
+
+run_test "IrisModel: Wrong data type (string instead of number)" 400 '{
+    "image": "irismodel:latest",
+    "input": [{
+        "sepal_length_cm": "not_a_number",
+        "sepal_width_cm": 3.5,
+        "petal_length_cm": 1.4,
+        "petal_width_cm": 0.2
+    }]
+}'
+
+run_test "IrisModel: Multiple items, one invalid" 400 '{
+    "image": "irismodel:latest",
+    "input": [
+        {
+            "sepal_length_cm": 5.1,
+            "sepal_width_cm": 3.5,
+            "petal_length_cm": 1.4,
+            "petal_width_cm": 0.2
+        },
+        {
+            "sepal_length_cm": 7.0,
+            "sepal_width_cm": 3.2,
+            "petal_length_cm": 4.7
+        }
+    ]
+}'
+
+# ====================
+# DPCGANSModel Tests
+# ====================
+echo -e "${YELLOW}--- DPCGANSModel Tests ---${NC}"
+echo ""
+
+run_test "DPCGANSModel: Valid input (permissive output schema)" 200 '{
+    "image": "dpcgansmodel:latest",
+    "input": [{
+        "num_rows": 5,
+        "max_retries": 50,
+        "max_rows_multiplier": 10,
+        "float_rtol": 0.01,
+        "graceful_reject_sampling": true
+    }]
+}'
+
+run_test "DPCGANSModel: Missing multiple required fields" 400 '{
+    "image": "dpcgansmodel:latest",
+    "input": [{
+        "max_retries": 50
+    }]
+}'
+
+run_test "DPCGANSModel: Wrong type for num_rows (string instead of integer)" 400 '{
+    "image": "dpcgansmodel:latest",
+    "input": [{
+        "num_rows": "five",
+        "max_retries": 50,
+        "max_rows_multiplier": 10,
+        "float_rtol": 0.01,
+        "graceful_reject_sampling": true
+    }]
+}'
+
+# ====================
+# CoxCOPDModel Tests (YAML Schema Format with Enums)
+# ====================
+echo -e "${YELLOW}--- CoxCOPDModel Tests (YAML Schema with Enums) ---${NC}"
+echo ""
+
+run_test "CoxCOPDModel: Valid input with correct enum values" 200 '{
+    "image": "coxcopdmodel:latest",
+    "input": [{
+        "ethnicity": "Not Hispanic or Latino",
+        "sex_at_birth": "Female",
+        "obesity": 0.0,
+        "diabetes": 0.0,
+        "cardiovascular_disease": 0.0,
+        "smoking_status": 1.0,
+        "alcohol_use": 0.0,
+        "bmi": 25.5,
+        "age_at_time_0": 65
+    }]
+}'
+
+run_test "CoxCOPDModel: Valid input with alternate enum values" 200 '{
+    "image": "coxcopdmodel:latest",
+    "input": [{
+        "ethnicity": "Hispanic or Latino",
+        "sex_at_birth": "Male",
+        "obesity": 1.0,
+        "diabetes": 0.0,
+        "cardiovascular_disease": 0.0,
+        "smoking_status": 0.0,
+        "alcohol_use": 1.0,
+        "bmi": 28.0,
+        "age_at_time_0": 55
+    }]
+}'
+
+run_test "CoxCOPDModel: Invalid ethnicity enum value" 400 '{
+    "image": "coxcopdmodel:latest",
+    "input": [{
+        "ethnicity": "Caucasian",
+        "sex_at_birth": "Female",
+        "obesity": 0.0,
+        "diabetes": 0.0,
+        "cardiovascular_disease": 0.0,
+        "smoking_status": 0.0,
+        "alcohol_use": 0.0,
+        "bmi": 25.0,
+        "age_at_time_0": 50
+    }]
+}'
+
+run_test "CoxCOPDModel: Invalid sex_at_birth enum value" 400 '{
+    "image": "coxcopdmodel:latest",
+    "input": [{
+        "ethnicity": "Hispanic or Latino",
+        "sex_at_birth": "Unknown",
+        "obesity": 0.0,
+        "diabetes": 0.0,
+        "cardiovascular_disease": 0.0,
+        "smoking_status": 0.0,
+        "alcohol_use": 0.0,
+        "bmi": 25.0,
+        "age_at_time_0": 50
+    }]
+}'
+
+run_test "CoxCOPDModel: Both enum values invalid" 400 '{
+    "image": "coxcopdmodel:latest",
+    "input": [{
+        "ethnicity": "White",
+        "sex_at_birth": "M",
+        "obesity": 0.0,
+        "diabetes": 0.0,
+        "cardiovascular_disease": 0.0,
+        "smoking_status": 0.0,
+        "alcohol_use": 0.0,
+        "bmi": 25.0,
+        "age_at_time_0": 50
+    }]
+}'
+
+run_test "CoxCOPDModel: Missing multiple required fields" 400 '{
+    "image": "coxcopdmodel:latest",
+    "input": [{
+        "ethnicity": "Not Hispanic or Latino",
+        "sex_at_birth": "Male"
+    }]
+}'
+
+run_test "CoxCOPDModel: Extra unexpected fields" 400 '{
+    "image": "coxcopdmodel:latest",
+    "input": [{
+        "ethnicity": "Not Hispanic or Latino",
+        "sex_at_birth": "Male",
+        "obesity": 0.0,
+        "diabetes": 0.0,
+        "cardiovascular_disease": 0.0,
+        "smoking_status": 1.0,
+        "alcohol_use": 0.0,
+        "bmi": 25.5,
+        "age_at_time_0": 65,
+        "extra_field": "should_not_be_here",
+        "another_extra": 123
+    }]
+}'
+
+# ====================
+# API Registration Tests (JSON Schema Objects in Request Body)
+# ====================
+echo -e "${YELLOW}--- API Registration Tests (JSON Schema Objects) ---${NC}"
+echo ""
+
+# Helper function to run a registration test
+run_registration_test() {
+    local test_name="$1"
+    local expected_status="$2"
+    local curl_data="$3"
+
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+
+    echo -e "${BLUE}Test $TOTAL_TESTS: $test_name${NC}"
+
+    # Make request and capture both response and HTTP status
+    response=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/models" \
+        -H "Content-Type: application/json" \
+        -d "$curl_data")
+
+    # Extract HTTP status code (last line)
+    http_status=$(echo "$response" | tail -n 1)
+    # Extract response body (everything except last line)
+    response_body=$(echo "$response" | sed '$d')
+
+    # Check if status matches expected
+    if [ "$http_status" -eq "$expected_status" ]; then
+        echo -e "${GREEN}✓ PASS${NC} - Got expected status $http_status"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+
+        # Show response for debugging (truncated if too long)
+        if [ ${#response_body} -gt 200 ]; then
+            echo "Response: ${response_body:0:200}..."
+        else
+            echo "Response: $response_body"
+        fi
+    else
+        echo -e "${RED}✗ FAIL${NC} - Expected status $expected_status, got $http_status"
+        echo "Response: $response_body"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    fi
+
+    echo ""
+}
+
+# Test: Re-register IrisModel with API-provided JSON schemas (should succeed)
+run_registration_test "Register with API JSON schema objects" 200 '{
+    "image": "irismodel:latest",
+    "title": "Iris Model (API Schema Test)",
+    "short_description": "Test registration with API-provided JSON schema objects",
+    "authors": "Test Suite",
+    "examples": [{"sepal_length_cm": 5.1, "sepal_width_cm": 3.5, "petal_length_cm": 1.4, "petal_width_cm": 0.2}],
+    "readme": "# Iris Model Test\nThis is a test registration with API-provided schemas.",
+    "input_schema": {
+        "id": "https://test/iris/input",
+        "name": "iris_test_input",
+        "prefixes": {"linkml": "https://w3id.org/linkml/"},
+        "imports": ["linkml:types"],
+        "default_range": "string",
+        "classes": {
+            "IrisTestInputItem": {
+                "attributes": {
+                    "sepal_length_cm": {"range": "float", "required": true},
+                    "sepal_width_cm": {"range": "float", "required": true},
+                    "petal_length_cm": {"range": "float", "required": true},
+                    "petal_width_cm": {"range": "float", "required": true}
+                }
+            }
+        }
+    },
+    "output_schema": {
+        "id": "https://test/iris/output",
+        "name": "iris_test_output",
+        "prefixes": {"linkml": "https://w3id.org/linkml/"},
+        "imports": ["linkml:types"],
+        "default_range": "string",
+        "classes": {
+            "IrisTestOutputItem": {
+                "attributes": {
+                    "prediction": {"range": "integer", "required": true}
+                }
+            }
+        }
+    }
+}'
+
+# Test: Prediction using API-registered model (validates the schema was applied)
+run_test "Predict with API-registered schemas" 200 '{
+    "image": "irismodel:latest",
+    "input": [{"sepal_length_cm": 5.1, "sepal_width_cm": 3.5, "petal_length_cm": 1.4, "petal_width_cm": 0.2}]
+}'
+
+# Test: Registration with invalid examples (should fail schema validation)
+run_registration_test "Register with examples that fail schema validation" 400 '{
+    "image": "irismodel:latest",
+    "title": "Iris Model (Bad Examples)",
+    "short_description": "This should fail because examples dont match schema",
+    "authors": "Test Suite",
+    "examples": [{"bad_field": "wrong"}],
+    "readme": "# Test",
+    "input_schema": {
+        "id": "https://test/iris/input",
+        "name": "iris_test_input",
+        "prefixes": {"linkml": "https://w3id.org/linkml/"},
+        "imports": ["linkml:types"],
+        "default_range": "string",
+        "classes": {
+            "IrisTestInputItem": {
+                "attributes": {
+                    "sepal_length_cm": {"range": "float", "required": true},
+                    "sepal_width_cm": {"range": "float", "required": true},
+                    "petal_length_cm": {"range": "float", "required": true},
+                    "petal_width_cm": {"range": "float", "required": true}
+                }
+            }
+        }
+    },
+    "output_schema": {
+        "id": "https://test/iris/output",
+        "name": "iris_test_output",
+        "prefixes": {"linkml": "https://w3id.org/linkml/"},
+        "imports": ["linkml:types"],
+        "default_range": "string",
+        "classes": {
+            "IrisTestOutputItem": {
+                "attributes": {
+                    "prediction": {"range": "integer", "required": true}
+                }
+            }
+        }
+    }
+}'
+
+# ====================
+# Summary
+# ====================
+echo -e "${YELLOW}======================================${NC}"
+echo -e "${YELLOW}Test Summary${NC}"
+echo -e "${YELLOW}======================================${NC}"
+echo "Total Tests: $TOTAL_TESTS"
+echo -e "Passed: ${GREEN}$PASSED_TESTS${NC}"
+echo -e "Failed: ${RED}$FAILED_TESTS${NC}"
+echo ""
+
+if [ $FAILED_TESTS -eq 0 ]; then
+    echo -e "${GREEN}✓ All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}✗ Some tests failed${NC}"
+    exit 1
+fi

--- a/app/model_server/models/test_validation.sh
+++ b/app/model_server/models/test_validation.sh
@@ -417,3 +417,33 @@ else
     echo -e "${RED}✗ Some tests failed${NC}"
     exit 1
 fi
+
+# ====================
+# ReachableFromModel Tests (reachable_from enum expansion)
+# ====================
+echo -e "${YELLOW}--- ReachableFromModel Tests (reachable_from) ---${NC}"
+echo ""
+
+run_test "ReachableFromModel: Valid ontology term" 200 '{
+    "image": "reachablefrommodel:latest",
+    "input": [{
+        "biological_sex": "PATO:0000383",
+        "age_years": 34
+    }]
+}'
+
+run_test "ReachableFromModel: Unknown custom value" 200 '{
+    "image": "reachablefrommodel:latest",
+    "input": [{
+        "biological_sex": "Unknown",
+        "age_years": 34
+    }]
+}'
+
+run_test "ReachableFromModel: Invalid ontology term" 400 '{
+    "image": "reachablefrommodel:latest",
+    "input": [{
+        "biological_sex": "PATO:9999998",
+        "age_years": 34
+    }]
+}'

--- a/app/model_server/pyproject.toml
+++ b/app/model_server/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "python-multipart (>=0.0.20,<0.0.21)",
     "pydantic (>=2.11.7,<3.0.0)",
     "linkml (>=1.8.0,<2.0.0)",
+    "linkml-term-validator (>=0.2.0,<0.3.0)",
+    "oaklib (>=0.6.0,<0.7.0)",
     "pyyaml (>=6.0.0,<7.0.0)",
 ]
 

--- a/app/model_server/pyproject.toml
+++ b/app/model_server/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "docker (>=7.1.0,<8.0.0)",
     "python-multipart (>=0.0.20,<0.0.21)",
     "pydantic (>=2.11.7,<3.0.0)",
+    "linkml (>=1.8.0,<2.0.0)",
+    "pyyaml (>=6.0.0,<7.0.0)",
 ]
 
 packages = [

--- a/app/model_server/pyproject.toml
+++ b/app/model_server/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "pydantic (>=2.11.7,<3.0.0)",
     "linkml (>=1.8.0,<2.0.0)",
     "linkml-term-validator (>=0.2.0,<0.3.0)",
-    "oaklib (>=0.6.0,<0.7.0)",
+    "oaklib[web] (>=0.6.0,<0.7.0)",
     "pyyaml (>=6.0.0,<7.0.0)",
 ]
 

--- a/app/router/router/routers/modeling.py
+++ b/app/router/router/routers/modeling.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Body, Path
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-from typing import List, Any, Optional
+from typing import List, Any, Optional, Dict
 import httpx
 import logging
 from ..config import settings  # expects settings.model_server_url
@@ -16,12 +16,88 @@ router = APIRouter(
 # --- Pydantic Models ---
 
 class RegisterRequest(BaseModel):
+    """
+    Request model for registering a new model.
+
+    Models require LinkML schemas for input/output validation. Schemas can be:
+    - Baked into the Docker image as /app/input_schema.yaml or /app/input_schema.json
+    - Provided via the input_schema and output_schema fields as JSON objects (overrides container schemas)
+
+    Container schemas can be YAML or JSON files. API schemas are JSON objects.
+    Examples must conform to the input_schema - validation will fail if they don't match.
+    Categorical fields (like ethnicity, sex_at_birth) use enum validation with specific allowed values.
+    """
     image: str = Field(..., example="coxcopdmodel:latest")
     title: str = Field(..., example="Cox PH Model for COPD Prediction (Demo)")
     short_description: str = Field(..., example="A survival model to predict risk and survival probability for COPD based on demographics and comorbidities.")
     authors: str = Field(..., example="Lakshmi Anandan, Shawn O'Neil")
-    examples: Optional[List[Any]] = Field(..., example=[{"ethnicity": "Not Hispanic or Latino", "sex_at_birth": "Female", "obesity": 0.0, "diabetes": 0.0, "cardiovascular_disease": 0.0, "smoking_status": 0.0, "alcohol_use": 0.0, "bmi": 25.0, "age_at_time_0": 50.0}, {"ethnicity": "Hispanic or Latino", "sex_at_birth": "Male", "obesity": 1.0, "diabetes": 1.0, "cardiovascular_disease": 1.0, "smoking_status": 1.0, "alcohol_use": 1.0, "bmi": 32.0, "age_at_time_0": 65.0}])
-    readme: Optional[str] = Field(..., example="## Cox PH Model for COPD Prediction\nThis model implements a Cox Proportional Hazards model using lifelines for survival analysis of COPD. It predicts partial hazard scores and survival probabilities at 5 years based on a set of demographic and comorbidity features.")
+    examples: Optional[List[Any]] = Field(None, example=[{"ethnicity": "Not Hispanic or Latino", "sex_at_birth": "Female", "obesity": 0.0, "diabetes": 0.0, "cardiovascular_disease": 0.0, "smoking_status": 0.0, "alcohol_use": 0.0, "bmi": 25.0, "age_at_time_0": 50.0}, {"ethnicity": "Hispanic or Latino", "sex_at_birth": "Male", "obesity": 1.0, "diabetes": 1.0, "cardiovascular_disease": 1.0, "smoking_status": 1.0, "alcohol_use": 1.0, "bmi": 32.0, "age_at_time_0": 65.0}])
+    readme: Optional[str] = Field(None, example="## Cox PH Model for COPD Prediction\nThis model implements a Cox Proportional Hazards model using lifelines for survival analysis of COPD. It predicts partial hazard scores and survival probabilities at 5 years based on a set of demographic and comorbidity features.")
+    input_schema: Optional[Dict[str, Any]] = Field(
+        None,
+        description="LinkML input schema as JSON object (overrides container schema)",
+        example={
+            "id": "https://w3id.org/charmtwinsights/coxcopdmodel/input",
+            "name": "coxcopd_input",
+            "description": "Input schema for Cox COPD survival model",
+            "prefixes": {"linkml": "https://w3id.org/linkml/"},
+            "imports": ["linkml:types"],
+            "default_range": "string",
+            "enums": {
+                "EthnicityEnum": {
+                    "description": "Patient ethnicity categories",
+                    "permissible_values": {
+                        "Not Hispanic or Latino": {"description": "Not Hispanic or Latino"},
+                        "Hispanic or Latino": {"description": "Hispanic or Latino"}
+                    }
+                },
+                "SexAtBirthEnum": {
+                    "description": "Biological sex at birth",
+                    "permissible_values": {
+                        "Female": {"description": "Female"},
+                        "Male": {"description": "Male"}
+                    }
+                }
+            },
+            "classes": {
+                "CoxCOPDInputItem": {
+                    "description": "Patient data for COPD risk prediction",
+                    "attributes": {
+                        "ethnicity": {"description": "Patient ethnicity", "range": "EthnicityEnum", "required": True},
+                        "sex_at_birth": {"description": "Biological sex at birth", "range": "SexAtBirthEnum", "required": True},
+                        "obesity": {"description": "Obesity status (0.0=no, 1.0=yes)", "range": "float", "required": True},
+                        "diabetes": {"description": "Diabetes status (0.0=no, 1.0=yes)", "range": "float", "required": True},
+                        "cardiovascular_disease": {"description": "Cardiovascular disease status", "range": "float", "required": True},
+                        "smoking_status": {"description": "Smoking status (0.0=no, 1.0=yes)", "range": "float", "required": True},
+                        "alcohol_use": {"description": "Alcohol use (0.0=no, 1.0=yes)", "range": "float", "required": True},
+                        "bmi": {"description": "Body Mass Index", "range": "float", "required": True},
+                        "age_at_time_0": {"description": "Patient age at baseline", "range": "float", "required": True}
+                    }
+                }
+            }
+        }
+    )
+    output_schema: Optional[Dict[str, Any]] = Field(
+        None,
+        description="LinkML output schema as JSON object (overrides container schema)",
+        example={
+            "id": "https://w3id.org/charmtwinsights/coxcopdmodel/output",
+            "name": "coxcopd_output",
+            "description": "Output schema for Cox COPD survival model",
+            "prefixes": {"linkml": "https://w3id.org/linkml/"},
+            "imports": ["linkml:types"],
+            "default_range": "string",
+            "classes": {
+                "CoxCOPDOutputItem": {
+                    "description": "COPD risk prediction result",
+                    "attributes": {
+                        "partial_hazard": {"description": "Partial hazard score from Cox model", "range": "float", "required": True},
+                        "survival_probability_5_years": {"description": "Predicted 5-year survival probability", "range": "float", "required": True}
+                    }
+                }
+            }
+        }
+    )
 
 class PredictRequest(BaseModel):
     image: str = Field(..., example="coxcopdmodel:latest")

--- a/model-templates/README.md
+++ b/model-templates/README.md
@@ -23,13 +23,17 @@ This guide helps you create and deploy machine learning models for CHARMTwinsigh
 ```
 my-model/
 ├── Dockerfile          # Container definition (minimal editing needed)
-├── predict.py/.R        # Your prediction code (EDIT THIS)
-├── predict              # Execution script (don't modify)
-├── README.md            # Model documentation (EDIT THIS)
-├── examples.json        # Test examples (EDIT THIS)
-├── pyproject.toml       # Python deps (EDIT THIS)
-└── DESCRIPTION          # R deps (EDIT THIS)
+├── predict.py/.R       # Your prediction code (EDIT THIS)
+├── predict             # Execution script (don't modify)
+├── README.md           # Model documentation (EDIT THIS)
+├── examples.json       # Test examples (EDIT THIS)
+├── input_schema.yaml   # Input validation schema (EDIT THIS) - or .json
+├── output_schema.yaml  # Output validation schema (EDIT THIS) - or .json
+├── pyproject.toml      # Python deps (EDIT THIS)
+└── DESCRIPTION         # R deps (EDIT THIS)
 ```
+
+**Note:** Schema files can be YAML (`.yaml`) or JSON (`.json`) format.
 
 ### Critical Rules
 
@@ -41,6 +45,8 @@ my-model/
 - A working `/predict` script
 - `README.md` with model documentation
 - `examples.json` with valid test data
+- `input_schema.yaml` or `input_schema.json` defining input structure
+- `output_schema.yaml` or `output_schema.json` defining output structure
 
 ## Python Models
 
@@ -214,6 +220,261 @@ Your model should return JSON results:
 ]
 ```
 
+## Input/Output Validation with LinkML
+
+CHARMTwinsights uses **LinkML schemas** to validate model inputs and outputs. Schemas are **required** for all models and ensure data quality at three critical points:
+
+1. **Registration**: Examples are validated against your input schema
+2. **Pre-execution**: Inputs are validated before running your model
+3. **Post-execution**: Outputs are validated to ensure contract compliance
+
+### What is LinkML?
+
+[LinkML](https://linkml.io/) (Linked Data Modeling Language) is a schema language for describing data structures. It's similar to JSON Schema but simpler and more readable.
+
+### Schema Format Support
+
+Schemas can be provided in **YAML** or **JSON** format:
+
+| Context | Supported Formats |
+|---------|-------------------|
+| **Container files** | `.yaml` or `.json` (either works) |
+| **API registration** | JSON object in request body |
+
+YAML is often preferred for hand-written schemas (more readable), while JSON objects are standard for REST API payloads.
+
+### Required Schema Files
+
+Your model must include two schema files:
+
+```
+my-model/
+├── input_schema.yaml   # Defines expected input structure (REQUIRED)
+├── output_schema.yaml  # Defines expected output structure (REQUIRED)
+├── predict.py          # Your model code
+├── ...
+```
+
+Or use JSON format:
+
+```
+my-model/
+├── input_schema.json   # Defines expected input structure (REQUIRED)
+├── output_schema.json  # Defines expected output structure (REQUIRED)
+├── predict.py          # Your model code
+├── ...
+```
+
+### Input Schema Example
+
+Create `input_schema.yaml` to define **one input item** (not the list):
+
+```yaml
+id: https://w3id.org/charmtwinsights/my-model/input
+name: my_model_input
+description: Input schema for my model
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  InputItem:
+    description: A single input record for prediction
+    attributes:
+      age:
+        description: Patient age in years
+        range: float
+        required: true
+
+      bmi:
+        description: Body mass index
+        range: float
+        required: true
+
+      smoking_status:
+        description: Current smoking status
+        range: string
+        required: true
+
+      id:
+        description: Optional identifier for tracking
+        range: string
+        required: false
+```
+
+### Output Schema Example
+
+Create `output_schema.yaml` to define **one output item**:
+
+```yaml
+id: https://w3id.org/charmtwinsights/my-model/output
+name: my_model_output
+description: Output schema for my model
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  OutputItem:
+    description: A single prediction result
+    attributes:
+      prediction:
+        description: Primary prediction value
+        range: float
+        required: true
+
+      confidence:
+        description: Confidence score (0.0 to 1.0)
+        range: float
+        required: false
+
+      id:
+        description: Identifier from input (if provided)
+        range: string
+        required: false
+```
+
+### Common Data Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `string` | Text values | `"category_a"` |
+| `integer` | Whole numbers | `42` |
+| `float` | Decimal numbers | `3.14` |
+| `boolean` | True/false | `true` |
+
+### Key Attributes
+
+- **`required: true`** - Field must be present
+- **`required: false`** - Field is optional (default)
+- **`description`** - Human-readable explanation
+- **`range`** - Data type for the field
+
+### Defining Categorical/Enum Fields
+
+For categorical fields with a fixed set of valid values, use LinkML enums:
+
+#### Approach 1: Separate Enum Definitions
+
+Define enums at the schema level and reference them in attributes:
+
+```yaml
+enums:
+  SexAtBirthEnum:
+    description: Biological sex at birth
+    permissible_values:
+      MALE:
+        description: Male
+      FEMALE:
+        description: Female
+      OTHER:
+        description: Other
+      UNKNOWN:
+        description: Unknown or not disclosed
+
+classes:
+  InputItem:
+    attributes:
+      sex_at_birth:
+        description: Biological sex at birth
+        range: SexAtBirthEnum  # Reference the enum
+        required: true
+```
+
+#### Approach 2: Inline permissible_values
+
+For single-use categorical fields:
+
+```yaml
+classes:
+  InputItem:
+    attributes:
+      risk_level:
+        description: Risk assessment category
+        permissible_values:
+          LOW:
+            description: Low risk (score 0-33)
+          MODERATE:
+            description: Moderate risk (score 34-66)
+          HIGH:
+            description: High risk (score 67-100)
+        required: true
+```
+
+### Updating Your Dockerfile
+
+Add your schema files to the Dockerfile:
+
+```dockerfile
+# Copy schema files (REQUIRED) - use .yaml or .json
+COPY input_schema.yaml output_schema.yaml ./
+
+# Or if using JSON format:
+# COPY input_schema.json output_schema.json ./
+```
+
+### Providing Schemas via API
+
+Alternatively, you can provide schemas as JSON objects in the registration API request:
+
+```json
+{
+  "image": "my-model:latest",
+  "title": "My Model",
+  "short_description": "Description",
+  "authors": "Your Name",
+  "input_schema": {
+    "id": "https://w3id.org/my-model/input",
+    "name": "my_input",
+    "prefixes": {"linkml": "https://w3id.org/linkml/"},
+    "imports": ["linkml:types"],
+    "default_range": "string",
+    "classes": {
+      "InputItem": {
+        "attributes": {
+          "feature1": {"range": "float", "required": true},
+          "feature2": {"range": "string", "required": true}
+        }
+      }
+    }
+  },
+  "output_schema": {
+    "id": "https://w3id.org/my-model/output",
+    "name": "my_output",
+    "prefixes": {"linkml": "https://w3id.org/linkml/"},
+    "imports": ["linkml:types"],
+    "default_range": "string",
+    "classes": {
+      "OutputItem": {
+        "attributes": {
+          "prediction": {"range": "float", "required": true}
+        }
+      }
+    }
+  }
+}
+```
+
+API-provided schemas override container schemas if both are present.
+
+**Note:** API schemas are proper JSON objects (not escaped strings). Container schemas can be YAML or JSON files.
+
+### More Information
+
+- [LinkML Documentation](https://linkml.io/linkml/)
+- [LinkML Schema Reference](https://linkml.io/linkml/schemas/index.html)
+- See built-in models for complete examples: `app/model_server/models/`
+
 ## Troubleshooting
 
 ### Build Errors
@@ -223,13 +484,18 @@ Your model should return JSON results:
 
 ### Registration Errors
 1. **"Examples required"**: Add `examples.json` or provide via API
-2. **"README required"**: Add `README.md` or provide via API  
+2. **"README required"**: Add `README.md` or provide via API
 3. **"Image not found"**: Build your Docker image first
+4. **"Input schema is required"**: Add `input_schema.yaml` or `input_schema.json` to container, or provide JSON via API
+5. **"Output schema is required"**: Add `output_schema.yaml` or `output_schema.json` to container, or provide JSON via API
+6. **"Examples validation failed"**: Your `examples.json` doesn't match your input schema
 
 ### Runtime Errors
 1. **Permission denied**: Make sure `predict` script is executable
 2. **Module not found**: Check your dependencies are installed
 3. **File paths**: Use relative paths from `/app` directory
+4. **"Input validation failed"**: Prediction request data doesn't match your input schema
+5. **"Output validation failed"**: Your model's output doesn't match your output schema
 
 ### Common Dockerfile Mistakes
 ```dockerfile

--- a/model-templates/README.md
+++ b/model-templates/README.md
@@ -545,3 +545,21 @@ See the `examples/` directory for complete working examples:
 - `examples/simple-classifier/` - Basic scikit-learn model
 - `examples/deep-learning/` - PyTorch model example
 - `examples/r-regression/` - R linear model example
+
+## Reachable-From (Ontology-backed enums)
+
+There is a minimal example that demonstrates `reachable_from` enum expansion using the public PATO ontology:
+
+- `model-templates/examples/reachable-from-demo/`
+
+This model uses a LinkML schema with:
+
+```
+reachable_from:
+  source_ontology: "http://purl.obolibrary.org/obo/pato.obo"
+  source_nodes:
+    - "PATO:0000047"
+  include_self: true
+```
+
+It is intended as a reference for how to structure schemas that need to enforce ontology-backed enums.

--- a/model-templates/README.md
+++ b/model-templates/README.md
@@ -552,6 +552,16 @@ There is a minimal example that demonstrates `reachable_from` enum expansion usi
 
 - `model-templates/examples/reachable-from-demo/`
 
+**What this enables**
+- Schema authors can restrict enum values to terms reachable from a root ontology term.
+- The model server expands `reachable_from` at **registration time** and stores the expanded schema.
+- Predictions validate against the expanded schema, so runtime calls are fast and deterministic.
+
+**Important behavior**
+- Expansion happens when a model is registered. If the ontology changes later, you must re-register the model to pick up changes.
+- Ontologies are downloaded on demand at registration time (not during prediction) and are not retained after expansion.
+- Prefer `.obo` URLs for smaller downloads; other formats may be significantly larger.
+
 This model uses a LinkML schema with:
 
 ```
@@ -563,3 +573,25 @@ reachable_from:
 ```
 
 It is intended as a reference for how to structure schemas that need to enforce ontology-backed enums.
+
+**Allowing values outside the ontology**
+If you need to allow values not in the ontology (e.g., missing/unknown), add explicit `permissible_values` entries.
+In order to be LinkML conformant, the keys for permissible values must match the `text:` entries exactly:
+
+```
+prefixes:
+  CHARM: https://example.org/charm/
+
+permissible_values:
+  Unknown:
+    text: Unknown
+    meaning: CHARM:Unknown
+    description: Unknown/missing value
+```
+
+**Supported enum features (current model server behavior)**
+- `reachable_from` on an enum
+- `include` / `minus` entries that contain `reachable_from`
+- `include` / `minus` entries that contain `permissible_values`
+
+Other advanced enum features in LinkML may parse, but only the above are actively expanded by the model server.

--- a/model-templates/examples/reachable-from-demo/Dockerfile
+++ b/model-templates/examples/reachable-from-demo/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY predict.py predict input_schema.yaml output_schema.yaml examples.json README.md ./
+
+RUN chmod +x predict

--- a/model-templates/examples/reachable-from-demo/README.md
+++ b/model-templates/examples/reachable-from-demo/README.md
@@ -1,0 +1,15 @@
+# Reachable-From Demo Model
+
+This example demonstrates how to use LinkML `reachable_from` to drive enum validation from an ontology.
+
+Key idea:
+- The input schema defines an enum whose permissible values are **expanded at registration time**
+  based on the ontology terms reachable from a root concept.
+
+In this example:
+- `source_ontology` points to the public PATO ontology (downloaded on demand).
+- `source_nodes` contains the root term `PATO:0000047` ("biological sex").
+- The expansion yields `PATO:0000047`, `PATO:0000383` (female), and `PATO:0000384` (male).
+- A custom `Unknown` value is included as a local extension using the `CHARM:` prefix.
+
+This model just echoes the input fields into a simple output so validation behavior is easy to see.

--- a/model-templates/examples/reachable-from-demo/examples.json
+++ b/model-templates/examples/reachable-from-demo/examples.json
@@ -1,0 +1,6 @@
+[
+  {
+    "biological_sex": "PATO:0000383",
+    "age_years": 34
+  }
+]

--- a/model-templates/examples/reachable-from-demo/input_schema.yaml
+++ b/model-templates/examples/reachable-from-demo/input_schema.yaml
@@ -1,0 +1,34 @@
+id: https://example.org/reachable-from-demo/input
+name: ReachableFromDemoInput
+description: Input schema demonstrating reachable_from expansion
+prefixes:
+  linkml: https://w3id.org/linkml/
+  PATO: http://purl.obolibrary.org/obo/PATO_
+  CHARM: https://example.org/charm/
+imports:
+  - linkml:types
+default_range: string
+
+enums:
+  BiologicalSexEnum:
+    description: Biological sex expanded from ontology
+    reachable_from:
+      source_ontology: "http://purl.obolibrary.org/obo/pato.obo"
+      source_nodes:
+        - "PATO:0000047"
+      include_self: true
+    permissible_values:
+      Unknown:
+        text: Unknown
+        meaning: CHARM:Unknown
+        description: Unknown/missing value
+
+classes:
+  InputRecord:
+    attributes:
+      biological_sex:
+        required: true
+        range: BiologicalSexEnum
+      age_years:
+        required: true
+        range: integer

--- a/model-templates/examples/reachable-from-demo/output_schema.yaml
+++ b/model-templates/examples/reachable-from-demo/output_schema.yaml
@@ -1,0 +1,18 @@
+id: https://example.org/reachable-from-demo/output
+name: ReachableFromDemoOutput
+description: Output schema for reachable_from demo
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+
+classes:
+  OutputRecord:
+    attributes:
+      normalized_sex:
+        required: true
+        range: string
+      is_adult:
+        required: true
+        range: boolean

--- a/model-templates/examples/reachable-from-demo/predict
+++ b/model-templates/examples/reachable-from-demo/predict
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 predict.py "$@"

--- a/model-templates/examples/reachable-from-demo/predict.py
+++ b/model-templates/examples/reachable-from-demo/predict.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+def main() -> int:
+    if len(sys.argv) not in (2, 3):
+        print("Usage: predict <input.json> [output.json]", file=sys.stderr)
+        return 1
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2] if len(sys.argv) == 3 else None
+
+    with open(input_file, "r") as f:
+        records = json.load(f)
+
+    outputs = []
+    for record in records:
+        age = record.get("age_years")
+        outputs.append({
+            "normalized_sex": record.get("biological_sex"),
+            "is_adult": bool(age is not None and age >= 18),
+        })
+
+    if output_file:
+        with open(output_file, "w") as f:
+            json.dump(outputs, f, indent=2)
+    else:
+        print(json.dumps(outputs))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/model-templates/examples/simple-classifier/Dockerfile
+++ b/model-templates/examples/simple-classifier/Dockerfile
@@ -19,5 +19,6 @@ COPY README.md ./
 COPY examples.json ./
 COPY train_model.py ./
 COPY simple_model.pkl ./
+COPY input_schema.yaml output_schema.yaml ./
 
 RUN chmod +x predict

--- a/model-templates/examples/simple-classifier/input_schema.yaml
+++ b/model-templates/examples/simple-classifier/input_schema.yaml
@@ -1,0 +1,35 @@
+# LinkML schema for Simple Classifier input validation
+# This schema defines the structure of ONE input item.
+
+id: https://w3id.org/charmtwinsights/simple-classifier/input
+name: simple_classifier_input
+description: Input schema for simple health risk classifier
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  SimpleClassifierInputItem:
+    description: Patient data for health risk prediction
+    attributes:
+      age:
+        description: Patient age in years
+        range: integer
+        required: true
+      bmi:
+        description: Body Mass Index
+        range: float
+        required: true
+      smoking:
+        description: Smoking status (0=non-smoker, 1=smoker)
+        range: integer
+        required: true
+      id:
+        description: Optional patient identifier for tracking
+        range: string
+        required: false

--- a/model-templates/examples/simple-classifier/output_schema.yaml
+++ b/model-templates/examples/simple-classifier/output_schema.yaml
@@ -1,0 +1,35 @@
+# LinkML schema for Simple Classifier output validation
+# This schema defines the structure of ONE output item.
+
+id: https://w3id.org/charmtwinsights/simple-classifier/output
+name: simple_classifier_output
+description: Output schema for simple health risk classifier
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  SimpleClassifierOutputItem:
+    description: Health risk prediction result
+    attributes:
+      risk_prediction:
+        description: Risk classification (0=low risk, 1=high risk)
+        range: integer
+        required: true
+      risk_probability:
+        description: Probability of high risk (0.0 to 1.0)
+        range: float
+        required: true
+      confidence:
+        description: Model confidence in prediction (0.0 to 1.0)
+        range: float
+        required: true
+      id:
+        description: Patient identifier (if provided in input)
+        range: string
+        required: false

--- a/model-templates/python-model/Dockerfile
+++ b/model-templates/python-model/Dockerfile
@@ -28,6 +28,7 @@ COPY predict.py ./
 COPY predict ./
 COPY README.md ./
 COPY examples.json ./
+COPY input_schema.yaml output_schema.yaml ./
 
 # Copy your model artifacts (adjust as needed)
 # COPY model_artifacts/ ./model_artifacts/

--- a/model-templates/python-model/examples.json
+++ b/model-templates/python-model/examples.json
@@ -7,7 +7,7 @@
   },
   {
     "feature1": 2.0,
-    "feature2": "category_b", 
+    "feature2": "category_b",
     "feature3": 38.2,
     "id": "test_2"
   }

--- a/model-templates/python-model/input_schema.yaml
+++ b/model-templates/python-model/input_schema.yaml
@@ -1,0 +1,96 @@
+# LinkML Schema for Model Input Validation
+# ===========================================
+#
+# This schema defines the structure of ONE input item.
+# The model_server validates each item in the input array separately.
+#
+# CUSTOMIZATION GUIDE:
+# 1. Update the id and name to match your model
+# 2. Rename the class (e.g., MyModelInputItem)
+# 3. Define your model's input attributes
+# 4. Set appropriate data types and requirements
+# 5. Add enum definitions for categorical fields with fixed values
+#
+# COMMON DATA TYPES:
+# - string: Text values
+# - integer: Whole numbers (1, 2, 3)
+# - float: Decimal numbers (1.5, 3.14)
+# - boolean: true/false values
+# - Enum: Categorical values with fixed set of options
+#
+# ATTRIBUTE OPTIONS:
+# - required: true/false - whether the field must be present
+# - description: Human-readable explanation of the field
+# - range: Data type (float, string, EnumName, etc.)
+# - minimum_value/maximum_value: Numeric constraints (optional)
+
+id: https://w3id.org/charmtwinsights/my-model/input
+name: my_model_input
+description: Input schema for my model - customize this description
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+# Example enumeration definitions for categorical features
+# Define these at the schema level and reference them in attributes
+enums:
+  RiskLevelEnum:
+    description: Clinical risk assessment categories
+    permissible_values:
+      LOW:
+        description: Low risk patient
+      MODERATE:
+        description: Moderate risk patient
+      HIGH:
+        description: High risk patient
+
+  TreatmentTypeEnum:
+    description: Type of treatment received
+    permissible_values:
+      NONE:
+        description: No treatment
+      MEDICATION:
+        description: Medication only
+      THERAPY:
+        description: Therapy only
+      COMBINED:
+        description: Combined medication and therapy
+
+classes:
+  InputItem:
+    description: A single input record for prediction - customize this description
+    attributes:
+      # Example numeric feature
+      age:
+        description: Patient age in years
+        range: float
+        required: true
+
+      # Example categorical feature with enum validation
+      risk_level:
+        description: Pre-assessment risk level
+        range: RiskLevelEnum
+        required: true
+
+      # Example optional categorical feature
+      treatment_type:
+        description: Type of treatment received (if any)
+        range: TreatmentTypeEnum
+        required: false
+
+      # Example numeric feature
+      biomarker_value:
+        description: Numeric biomarker measurement
+        range: float
+        required: true
+
+      # Optional ID field for tracking predictions
+      id:
+        description: Optional identifier for tracking this input through prediction
+        range: string
+        required: false

--- a/model-templates/python-model/output_schema.yaml
+++ b/model-templates/python-model/output_schema.yaml
@@ -1,0 +1,50 @@
+# LinkML Schema for Model Output Validation
+# ==========================================
+#
+# This schema defines the structure of ONE output item.
+# The model_server validates each item in the output array separately.
+#
+# CUSTOMIZATION GUIDE:
+# 1. Update the id and name to match your model
+# 2. Rename the class (e.g., MyModelOutputItem)
+# 3. Define your model's output attributes
+# 4. Ensure your predict.py outputs objects matching this schema
+#
+# IMPORTANT: Your model's output should be a list of objects like:
+# [{"prediction": 0.85, "confidence": 0.92}, {"prediction": 0.23, "confidence": 0.88}]
+#
+# NOT raw values like: [0.85, 0.23]
+
+id: https://w3id.org/charmtwinsights/my-model/output
+name: my_model_output
+description: Output schema for my model - customize this description
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  OutputItem:
+    description: A single prediction result - customize this description
+    attributes:
+      # Primary prediction value
+      prediction:
+        description: Primary prediction output (customize this)
+        range: float
+        required: true
+
+      # Optional confidence score
+      confidence:
+        description: Confidence score for the prediction (0.0 to 1.0)
+        range: float
+        required: false
+
+      # Optional ID passthrough
+      id:
+        description: Input identifier (if provided in input)
+        range: string
+        required: false

--- a/model-templates/r-model/Dockerfile
+++ b/model-templates/r-model/Dockerfile
@@ -30,6 +30,7 @@ COPY predict.R ./
 COPY predict ./
 COPY README.md ./
 COPY examples.json ./
+COPY input_schema.yaml output_schema.yaml ./
 
 # Copy your model artifacts (adjust as needed)
 # COPY model_artifacts/ ./model_artifacts/

--- a/model-templates/r-model/input_schema.yaml
+++ b/model-templates/r-model/input_schema.yaml
@@ -1,0 +1,64 @@
+# LinkML Schema for R Model Input Validation
+# ===========================================
+#
+# This schema defines the structure of ONE input item.
+# The model_server validates each item in the input array separately.
+#
+# CUSTOMIZATION GUIDE:
+# 1. Update the id and name to match your model
+# 2. Rename the class (e.g., MyModelInputItem)
+# 3. Define your model's input attributes
+# 4. Set appropriate data types and requirements
+# 5. Add enum definitions for categorical fields with fixed values
+#
+# COMMON DATA TYPES:
+# - string: Text values
+# - integer: Whole numbers (1, 2, 3)
+# - float: Decimal numbers (1.5, 3.14)
+# - boolean: true/false values
+# - Enum: Categorical values with fixed set of options
+
+id: https://w3id.org/charmtwinsights/r-model/input
+name: r_model_input
+description: Input schema for R model - customize this description
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+# Example enumeration for categorical features
+enums:
+  CategoryEnum:
+    description: Example categorical feature values
+    permissible_values:
+      category_a:
+        description: Category A
+      category_b:
+        description: Category B
+      category_c:
+        description: Category C
+
+classes:
+  RModelInputItem:
+    description: A single input record for prediction - customize this description
+    attributes:
+      feature1:
+        description: First numeric feature (customize this)
+        range: float
+        required: true
+      feature2:
+        description: Categorical feature with enum validation
+        range: CategoryEnum
+        required: true
+      feature3:
+        description: Third numeric feature (customize this)
+        range: float
+        required: true
+      id:
+        description: Optional identifier for tracking this input through prediction
+        range: string
+        required: false

--- a/model-templates/r-model/output_schema.yaml
+++ b/model-templates/r-model/output_schema.yaml
@@ -1,0 +1,36 @@
+# LinkML Schema for R Model Output Validation
+# ============================================
+#
+# This schema defines the structure of ONE output item.
+# The model_server validates each item in the output array separately.
+#
+# CUSTOMIZATION GUIDE:
+# 1. Update the id and name to match your model
+# 2. Rename the class (e.g., MyModelOutputItem)
+# 3. Define your model's output attributes
+# 4. Set appropriate data types and requirements
+
+id: https://w3id.org/charmtwinsights/r-model/output
+name: r_model_output
+description: Output schema for R model - customize this description
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+default_range: string
+
+classes:
+  RModelOutputItem:
+    description: A single prediction result - customize this description
+    attributes:
+      prediction:
+        description: Model prediction value
+        range: float
+        required: true
+      id:
+        description: Input identifier (if provided)
+        range: string
+        required: false


### PR DESCRIPTION
Addresses #32. 

LinkML schemas are now required metadata for model inputs and outputs. Validation is performed during registration (when examples are run) and on every input/output during use. Schemas can be baked into images with either .json or .yaml files, or as part of the registration body (via json data). Model-specific metadata also returns schema information. 

Added some tests via script and manually checked MCP compatibility.