### PR TITLE
DSTU2→R4 external FHIR import (Apple HealthKit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ app/timeseries_model/test_model_real_data.py
 
 # TimeAutoDiff raw data (downloaded for testing, not needed for inference)
 app/synthea_server/timeseries-generative-model/timeautodiff/raw_data/
+
+# Maven build output
+target/
+dependency-reduced-pom.xml

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -116,13 +116,21 @@ services:
   synthea_server:
     depends_on:
       - hapi
+      - fhir-converter
     build: ./synthea_server
+    environment:
+      - CONVERTER_URL=http://fhir-converter:8080
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 60s
+
+
+  fhir-converter:
+    build: ./fhir-converter
+    # no host port needed; internal only
 
 
   model_server:

--- a/app/fhir-converter/Dockerfile
+++ b/app/fhir-converter/Dockerfile
@@ -1,0 +1,14 @@
+# --- build ---
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /src
+COPY pom.xml .
+RUN mvn -q -e -DskipTests dependency:go-offline
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+# --- run ---
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /src/target/fhir-converter.jar /app/fhir-converter.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/fhir-converter.jar"]

--- a/app/fhir-converter/pom.xml
+++ b/app/fhir-converter/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.charm</groupId>
+  <artifactId>fhir-converter</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- Must match the org.hl7.fhir.core line shipped with HAPI 8.2.x.
+         Verify latest on Maven Central:
+         https://central.sonatype.com/artifact/ca.uhn.hapi.fhir/org.hl7.fhir.convertors
+         hapi-fhir 8.2.0's parent pom pins fhir_core_version to 6.5.18. -->
+    <fhir.core.version>6.5.18</fhir.core.version>
+  </properties>
+
+  <dependencies>
+    <!-- Pulls org.hl7.fhir.dstu2 and org.hl7.fhir.r4 transitively -->
+    <dependency>
+      <groupId>ca.uhn.hapi.fhir</groupId>
+      <artifactId>org.hl7.fhir.convertors</artifactId>
+      <version>${fhir.core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>fhir-converter</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <filters>
+                <!-- Strip signature files from shaded dependencies; otherwise the
+                     merged manifest can fail signature verification at runtime
+                     ("Invalid signature file digest for Manifest main attributes"). -->
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.charm.converter.ConverterServer</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/app/fhir-converter/src/main/java/org/charm/converter/ConverterServer.java
+++ b/app/fhir-converter/src/main/java/org/charm/converter/ConverterServer.java
@@ -7,23 +7,35 @@ import java.nio.charset.StandardCharsets;
 
 public class ConverterServer {
   public static void main(String[] args) throws Exception {
-    HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+    HttpServer server = start(8080);
+    System.out.println("fhir-converter listening on :" + server.getAddress().getPort());
+  }
+
+  /**
+   * Build, wire, and start an {@link HttpServer} bound to the given port
+   * (pass {@code 0} for an ephemeral port, e.g. in tests). Registers the same
+   * {@code /health} and {@code /convert} handlers used in production.
+   */
+  public static HttpServer start(int port) throws java.io.IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
     server.createContext("/health", ex -> respond(ex, 200, "{\"status\":\"ok\"}"));
-    server.createContext("/convert", ex -> {
-      if (!"POST".equals(ex.getRequestMethod())) { respond(ex, 405, oo("not-supported","POST only")); return; }
-      try (InputStream is = ex.getRequestBody()) {
-        String body = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-        // body = {"sourceVersion":"DSTU2","bundle":{...}} ; extract the bundle object.
-        String bundleJson = JsonBody.extractBundle(body);
-        String r4 = ConverterService.convertBundleDstu2ToR4(bundleJson);
-        respond(ex, 200, r4);
-      } catch (Exception e) {
-        respond(ex, 400, oo("processing", e.getMessage() == null ? "conversion error" : e.getMessage()));
-      }
-    });
+    server.createContext("/convert", ConverterServer::handleConvert);
     server.setExecutor(java.util.concurrent.Executors.newFixedThreadPool(4));
     server.start();
-    System.out.println("fhir-converter listening on :8080");
+    return server;
+  }
+
+  private static void handleConvert(com.sun.net.httpserver.HttpExchange ex) throws java.io.IOException {
+    if (!"POST".equals(ex.getRequestMethod())) { respond(ex, 405, oo("not-supported","POST only")); return; }
+    try (InputStream is = ex.getRequestBody()) {
+      String body = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+      // body = {"sourceVersion":"DSTU2","bundle":{...}} ; extract the bundle object.
+      String bundleJson = JsonBody.extractBundle(body);
+      String r4 = ConverterService.convertBundleDstu2ToR4(bundleJson);
+      respond(ex, 200, r4);
+    } catch (Exception e) {
+      respond(ex, 400, oo("processing", e.getMessage() == null ? "conversion error" : e.getMessage()));
+    }
   }
 
   private static void respond(com.sun.net.httpserver.HttpExchange ex, int code, String json) throws java.io.IOException {

--- a/app/fhir-converter/src/main/java/org/charm/converter/ConverterServer.java
+++ b/app/fhir-converter/src/main/java/org/charm/converter/ConverterServer.java
@@ -1,0 +1,41 @@
+package org.charm.converter;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+public class ConverterServer {
+  public static void main(String[] args) throws Exception {
+    HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+    server.createContext("/health", ex -> respond(ex, 200, "{\"status\":\"ok\"}"));
+    server.createContext("/convert", ex -> {
+      if (!"POST".equals(ex.getRequestMethod())) { respond(ex, 405, oo("not-supported","POST only")); return; }
+      try (InputStream is = ex.getRequestBody()) {
+        String body = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        // body = {"sourceVersion":"DSTU2","bundle":{...}} ; extract the bundle object.
+        String bundleJson = JsonBody.extractBundle(body);
+        String r4 = ConverterService.convertBundleDstu2ToR4(bundleJson);
+        respond(ex, 200, r4);
+      } catch (Exception e) {
+        respond(ex, 400, oo("processing", e.getMessage() == null ? "conversion error" : e.getMessage()));
+      }
+    });
+    server.setExecutor(java.util.concurrent.Executors.newFixedThreadPool(4));
+    server.start();
+    System.out.println("fhir-converter listening on :8080");
+  }
+
+  private static void respond(com.sun.net.httpserver.HttpExchange ex, int code, String json) throws java.io.IOException {
+    byte[] b = json.getBytes(StandardCharsets.UTF_8);
+    ex.getResponseHeaders().set("Content-Type", "application/fhir+json");
+    ex.sendResponseHeaders(code, b.length);
+    ex.getResponseBody().write(b);
+    ex.close();
+  }
+
+  private static String oo(String code, String diag) {
+    return "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"error\",\"code\":\""
+        + code + "\",\"diagnostics\":" + JsonBody.quote(diag) + "}]}";
+  }
+}

--- a/app/fhir-converter/src/main/java/org/charm/converter/ConverterService.java
+++ b/app/fhir-converter/src/main/java/org/charm/converter/ConverterService.java
@@ -1,0 +1,67 @@
+package org.charm.converter;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_10_40;
+import org.hl7.fhir.dstu2.model.Resource;
+
+import java.nio.charset.StandardCharsets;
+
+public final class ConverterService {
+  private ConverterService() {}
+
+  /**
+   * Convert a DSTU2 bundle JSON to an R4 collection bundle JSON, entry by entry.
+   *
+   * <p>Deliberately does NOT parse the DSTU2 bundle as a whole with HAPI's DSTU2
+   * {@code JsonParser}: that parser eagerly parses every entry's resource while
+   * walking the bundle, so a single unrecognized/unconvertible entry resource
+   * would abort parsing of the entire bundle. Instead the raw JSON structure is
+   * walked with Gson, and each entry's resource JSON is parsed and converted
+   * independently so a bad entry can be skipped without losing the rest.
+   */
+  public static String convertBundleDstu2ToR4(String dstu2BundleJson) {
+    try {
+      JsonElement rootEl = com.google.gson.JsonParser.parseString(dstu2BundleJson);
+      if (!rootEl.isJsonObject()) {
+        throw new IllegalArgumentException("Input is not a JSON object");
+      }
+      JsonObject root = rootEl.getAsJsonObject();
+      String resourceType = root.has("resourceType") ? root.get("resourceType").getAsString() : null;
+      if (!"Bundle".equals(resourceType)) {
+        throw new IllegalArgumentException("Top-level resource is not a Bundle");
+      }
+
+      org.hl7.fhir.r4.model.Bundle out = new org.hl7.fhir.r4.model.Bundle();
+      out.setType(org.hl7.fhir.r4.model.Bundle.BundleType.COLLECTION);
+
+      JsonArray entries = root.has("entry") ? root.getAsJsonArray("entry") : new JsonArray();
+      org.hl7.fhir.dstu2.formats.JsonParser d2 = new org.hl7.fhir.dstu2.formats.JsonParser();
+
+      for (JsonElement entryEl : entries) {
+        if (!entryEl.isJsonObject()) continue;
+        JsonObject entryObj = entryEl.getAsJsonObject();
+        if (!entryObj.has("resource") || !entryObj.get("resource").isJsonObject()) continue;
+        String resourceJson = entryObj.get("resource").toString();
+        try {
+          Resource dstu2Resource =
+              d2.parse(resourceJson.getBytes(StandardCharsets.UTF_8));
+          org.hl7.fhir.r4.model.Resource r4res =
+              (org.hl7.fhir.r4.model.Resource) VersionConvertorFactory_10_40.convertResource(dstu2Resource);
+          out.addEntry().setResource(r4res);
+        } catch (Exception skip) {
+          // Per-resource failure (unparseable or unconvertible): skip this entry, keep converting the rest.
+          System.err.println("Skipping unconvertible entry: " + skip.getMessage());
+        }
+      }
+
+      org.hl7.fhir.r4.formats.JsonParser r4parser = new org.hl7.fhir.r4.formats.JsonParser();
+      return r4parser.composeString(out);
+    } catch (RuntimeException re) {
+      throw re;
+    } catch (Exception ex) {
+      throw new RuntimeException("DSTU2->R4 conversion failed: " + ex.getMessage(), ex);
+    }
+  }
+}

--- a/app/fhir-converter/src/main/java/org/charm/converter/JsonBody.java
+++ b/app/fhir-converter/src/main/java/org/charm/converter/JsonBody.java
@@ -1,0 +1,17 @@
+package org.charm.converter;
+
+public final class JsonBody {
+  private JsonBody() {}
+
+  /** Extract the value of the top-level "bundle" key from the request JSON. */
+  public static String extractBundle(String requestJson) {
+    com.google.gson.JsonObject root = com.google.gson.JsonParser.parseString(requestJson).getAsJsonObject();
+    if (!root.has("bundle")) throw new IllegalArgumentException("request missing 'bundle'");
+    return root.get("bundle").toString();
+  }
+
+  public static String quote(String s) {
+    return com.google.gson.JsonParser.parseString(
+        new com.google.gson.Gson().toJson(s == null ? "" : s)).toString();
+  }
+}

--- a/app/fhir-converter/src/test/java/org/charm/converter/ConverterServerTest.java
+++ b/app/fhir-converter/src/test/java/org/charm/converter/ConverterServerTest.java
@@ -1,0 +1,81 @@
+package org.charm.converter;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test against the real {@link ConverterServer} HTTP handlers
+ * (not a reimplementation): starts the actual server on an ephemeral port
+ * and drives it with real HTTP requests via {@link HttpClient}.
+ */
+class ConverterServerTest {
+
+  private HttpServer server;
+  private HttpClient client;
+  private String baseUrl;
+
+  @BeforeEach
+  void startServer() throws Exception {
+    server = ConverterServer.start(0); // ephemeral port
+    int port = server.getAddress().getPort();
+    baseUrl = "http://localhost:" + port;
+    client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) server.stop(0);
+  }
+
+  @Test
+  void convertReturns200WithConvertedResource() throws Exception {
+    String requestBody = """
+      {"sourceVersion":"DSTU2","bundle":
+        {"resourceType":"Bundle","type":"collection","entry":[
+          {"resource":{"resourceType":"MedicationOrder","id":"13","status":"active",
+           "dateWritten":"2023-10-20","patient":{"reference":"Patient/100"},
+           "medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm/","code":"1"}]}}}
+        ]}}""";
+
+    HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl + "/convert"))
+        .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+        .build();
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("MedicationRequest"));
+  }
+
+  @Test
+  void convertMissingBundleReturns400WithOperationOutcome() throws Exception {
+    String requestBody = "{\"sourceVersion\":\"DSTU2\"}";
+
+    HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl + "/convert"))
+        .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+        .build();
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(400, response.statusCode());
+    assertTrue(response.body().contains("\"resourceType\":\"OperationOutcome\""));
+  }
+
+  @Test
+  void convertWrongMethodReturns405() throws Exception {
+    HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl + "/convert"))
+        .GET()
+        .build();
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(405, response.statusCode());
+  }
+}

--- a/app/fhir-converter/src/test/java/org/charm/converter/ConverterServiceTest.java
+++ b/app/fhir-converter/src/test/java/org/charm/converter/ConverterServiceTest.java
@@ -1,0 +1,31 @@
+package org.charm.converter;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConverterServiceTest {
+  // Minimal DSTU2 bundle: one MedicationOrder (renamed MedicationRequest in R4)
+  private static final String DSTU2 = """
+    {"resourceType":"Bundle","type":"collection","entry":[
+      {"resource":{"resourceType":"MedicationOrder","id":"13","status":"active",
+       "dateWritten":"2023-10-20","patient":{"reference":"Patient/100"},
+       "medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm/","code":"1"}]}}}
+    ]}""";
+
+  @Test
+  void convertsMedicationOrderToMedicationRequest() {
+    String r4 = ConverterService.convertBundleDstu2ToR4(DSTU2);
+    assertTrue(r4.contains("\"resourceType\":\"Bundle\""));
+    assertTrue(r4.contains("MedicationRequest"), "MedicationOrder should become MedicationRequest");
+    assertFalse(r4.contains("MedicationOrder"), "no DSTU2 MedicationOrder should remain");
+  }
+
+  @Test
+  void badResourceIsSkippedNotFatal() {
+    String bundle = "{\"resourceType\":\"Bundle\",\"type\":\"collection\",\"entry\":[" +
+        "{\"resource\":{\"resourceType\":\"NotAResource\"}}]}";
+    // Unknown resource: entry skipped, still returns a valid empty R4 bundle
+    String r4 = ConverterService.convertBundleDstu2ToR4(bundle);
+    assertTrue(r4.contains("\"resourceType\":\"Bundle\""));
+  }
+}

--- a/app/fhir-converter/src/test/java/org/charm/converter/ConverterServiceTest.java
+++ b/app/fhir-converter/src/test/java/org/charm/converter/ConverterServiceTest.java
@@ -28,4 +28,28 @@ class ConverterServiceTest {
     String r4 = ConverterService.convertBundleDstu2ToR4(bundle);
     assertTrue(r4.contains("\"resourceType\":\"Bundle\""));
   }
+
+  @Test
+  void mixedBundleSkipsBadEntryButKeepsGoodEntry() {
+    // One good MedicationOrder entry alongside one bad/unknown-resource-type entry.
+    // Asserts that the bad entry is dropped WHILE the good entry survives -- this
+    // is what distinguishes "skip the bad entry, keep converting the rest" from
+    // "abort and return an empty bundle on any per-entry error".
+    String bundle = """
+      {"resourceType":"Bundle","type":"collection","entry":[
+        {"resource":{"resourceType":"MedicationOrder","id":"13","status":"active",
+         "dateWritten":"2023-10-20","patient":{"reference":"Patient/100"},
+         "medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm/","code":"1"}]}}},
+        {"resource":{"resourceType":"NotAResource"}}
+      ]}""";
+
+    String r4 = ConverterService.convertBundleDstu2ToR4(bundle);
+
+    assertTrue(r4.contains("MedicationRequest"), "the good entry should survive conversion");
+
+    com.google.gson.JsonObject out = com.google.gson.JsonParser.parseString(r4).getAsJsonObject();
+    com.google.gson.JsonArray outEntries = out.getAsJsonArray("entry");
+    assertEquals(1, outEntries.size(),
+        "exactly one entry should remain: the bad entry dropped, the good entry preserved");
+  }
 }

--- a/app/mcp_server/test_mcp.sh
+++ b/app/mcp_server/test_mcp.sh
@@ -258,17 +258,17 @@ if ! echo "$ingest_response" | jq -e --arg cohort "$fixture_cohort" '
   exit 1
 fi
 
-prefixed_patient_id="$(echo "$ingest_response" | jq -r '.patient_ids[0] // empty')"
-if [ -z "$prefixed_patient_id" ] || [[ "$prefixed_patient_id" != ext-* ]]; then
-  error "Expected prefixed patient id, got '${prefixed_patient_id}'"
+server_patient_id="$(echo "$ingest_response" | jq -r '.patient_ids[0] // empty')"
+if [ -z "$server_patient_id" ]; then
+  error "Expected a non-empty server-assigned patient id, got '${server_patient_id}'"
   exit 1
 fi
 
-log "Fixture ingested for patient ${prefixed_patient_id}; executing MCP workflow validation"
+log "Fixture ingested for patient ${server_patient_id}; executing MCP workflow validation"
 (
   cd "$APP_DIR"
   docker compose exec -T \
-    -e CI_MCP_PATIENT_ID="$prefixed_patient_id" \
+    -e CI_MCP_PATIENT_ID="$server_patient_id" \
     -e CI_MCP_PATIENT_GIVEN="$fixture_given" \
     -e CI_MCP_PATIENT_FAMILY="$fixture_family" \
     -e CI_MCP_PATIENT_BIRTHDATE="$fixture_birthdate" \

--- a/app/router/router/routers/ingestion.py
+++ b/app/router/router/routers/ingestion.py
@@ -124,12 +124,13 @@ class ExternalFHIRIngestRequest(BaseModel):
         }
     )
     datatype: str = Field(
-        "external", 
+        "external",
         description="Data type classification - must be 'external' or 'synthetic'",
         json_schema_extra={
             "example": "external"
         }
     )
+    source_fhir_version: str = Field("R4", description="Source FHIR version: 'R4' or 'DSTU2'")
 
 
 @router.post("/fhir", response_class=JSONResponse)
@@ -197,7 +198,8 @@ async def ingest_external_fhir(request: ExternalFHIRIngestRequest):
     request_data = {
         "bundle": request.bundle,
         "cohort_id": request.cohort_id,
-        "datatype": request.datatype
+        "datatype": request.datatype,
+        "source_fhir_version": request.source_fhir_version
     }
     
     try:

--- a/app/router/router/routers/ingestion.py
+++ b/app/router/router/routers/ingestion.py
@@ -138,14 +138,20 @@ async def ingest_external_fhir(request: ExternalFHIRIngestRequest):
     """
     Ingest FHIR bundle from external sources (e.g., mobile apps, wearables, EHRs).
     
-    This endpoint accepts a FHIR Bundle containing patient data from external sources,
-    automatically prefixes patient IDs with 'ext-' to prevent conflicts with synthetic data,
-    applies appropriate CHARM tags for cohort organization, and stores the data in HAPI FHIR.
-    
+    This endpoint accepts a FHIR Bundle containing patient data from external sources
+    (converting from DSTU2 to R4 first if needed), isolates it from synthetic data by
+    letting the server assign new resource ids and moving any incoming ids into an
+    identifier used for conditional-create deduplication, applies appropriate CHARM
+    tags for cohort organization, and stores the data in HAPI FHIR.
+
     ## Features
-    
-    - **ID Prefixing**: All Patient IDs are automatically prefixed with 'ext-' to prevent conflicts
-    - **Reference Updates**: All references to patients throughout the bundle are updated accordingly
+
+    - **ID Isolation**: Resources are stored with server-assigned ids; any incoming id
+      is preserved as an identifier (not reused as the resource id) so imported data
+      cannot collide with existing synthetic or previously imported records
+    - **Identifier-Based Dedup**: Resources carrying an identifier are conditionally
+      created (`ifNoneExist`), so re-submitting the same source data updates rather
+      than duplicates existing records
     - **Transaction Bundles**: Bundles are converted to transaction type for atomic operations
     - **Update Support**: Re-submitting data for the same patient updates existing records
     - **Automatic Tagging**: Data is tagged with CHARM metadata for cohort organization
@@ -182,7 +188,7 @@ async def ingest_external_fhir(request: ExternalFHIRIngestRequest):
     - `cohort_id`: The cohort ID used
     - `datatype`: The datatype classification
     - `patient_count`: Number of patients in the bundle
-    - `patient_ids`: Array of prefixed patient IDs
+    - `patient_ids`: Array of server-assigned patient IDs
     - `tags_applied`: Dictionary of tags applied to resources
     
     ## Error Handling

--- a/app/synthea_server/poetry.lock
+++ b/app/synthea_server/poetry.lock
@@ -186,12 +186,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main"]
-markers = "platform_system == \"Windows\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "fastapi"
@@ -340,6 +340,18 @@ files = [
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
 
 [[package]]
 name = "jinja2"
@@ -847,7 +859,7 @@ version = "26.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
@@ -1083,6 +1095,22 @@ express = ["numpy"]
 kaleido = ["kaleido (>=1.1.0)"]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 description = "Data validation using Python type hints"
@@ -1237,6 +1265,43 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.14.1"
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9"},
+    {file = "pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -1732,4 +1797,4 @@ standard = ["colorama (>=0.4)", "httptools (>=0.6.3)", "python-dotenv (>=0.13)",
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4"
-content-hash = "052dd0cb8503b6cbda1e943ccc1b515ee553003f78a838a02a6516c4f0bfc652"
+content-hash = "5559733b28ee8f1432fb7328774a78e8a1dcc6fb801035691c5ca51985d930e2"

--- a/app/synthea_server/pyproject.toml
+++ b/app/synthea_server/pyproject.toml
@@ -24,6 +24,12 @@ tqdm = ">=4.0.0"
 plotly = ">=5.0.0"
 reportlab = "^4.4.10"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2.0"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+testpaths = ["synthea-pyserver/tests"]

--- a/app/synthea_server/synthea-pyserver/external_import.py
+++ b/app/synthea_server/synthea-pyserver/external_import.py
@@ -127,6 +127,11 @@ def build_isolation_transaction(bundle: dict) -> tuple[dict, list[dict]]:
         if ident is not None:
             token = f"{ident[0]}|{ident[1]}"
             req["ifNoneExist"] = f"identifier={_urlquote(token, safe=':')}"
+        # else: no identifier and no id, so nothing to key ifNoneExist on -
+        # this is a plain POST with no dedup, and re-importing the same bundle
+        # will duplicate this resource. Acceptable because every resource in
+        # target bundles carries at least a bare id, which is synthesized into
+        # an identifier above.
         e["request"] = req
 
     bundle["type"] = "transaction"

--- a/app/synthea_server/synthea-pyserver/external_import.py
+++ b/app/synthea_server/synthea-pyserver/external_import.py
@@ -147,3 +147,11 @@ def convert_bundle(bundle: dict, source_version: str, converter_url: str, sessio
     if resp.status_code not in (200, 201):
         raise ConversionError(f"converter returned {resp.status_code}: {resp.text[:500]}")
     return resp.json()
+
+
+def assemble_external_import(bundle: dict, source_fhir_version: str | None,
+                             converter_url: str, session=None) -> tuple[dict, list[dict]]:
+    version = detect_fhir_version(bundle, hint=source_fhir_version)
+    r4 = convert_bundle(bundle, version, converter_url, session=session)
+    stubbed = synthesize_stub_patients(r4)
+    return build_isolation_transaction(stubbed)

--- a/app/synthea_server/synthea-pyserver/external_import.py
+++ b/app/synthea_server/synthea-pyserver/external_import.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import copy
 import uuid
 from urllib.parse import quote as _urlquote
+import requests
 
 # Resource types that were renamed/removed after DSTU2 (strong DSTU2 signal).
 _DSTU2_ONLY_TYPES = {"MedicationOrder", "DeviceUseRequest", "DiagnosticOrder", "BodySite"}
@@ -130,3 +131,19 @@ def build_isolation_transaction(bundle: dict) -> tuple[dict, list[dict]]:
 
     bundle["type"] = "transaction"
     return bundle, unresolved
+
+
+class ConversionError(Exception):
+    pass
+
+
+def convert_bundle(bundle: dict, source_version: str, converter_url: str, session=None) -> dict:
+    if source_version.upper() == "R4":
+        return bundle
+    sess = session or requests.Session()
+    url = converter_url.rstrip("/") + "/convert"
+    resp = sess.post(url, json={"sourceVersion": "DSTU2", "bundle": bundle},
+                     headers={"Content-Type": "application/json"}, timeout=120)
+    if resp.status_code not in (200, 201):
+        raise ConversionError(f"converter returned {resp.status_code}: {resp.text[:500]}")
+    return resp.json()

--- a/app/synthea_server/synthea-pyserver/external_import.py
+++ b/app/synthea_server/synthea-pyserver/external_import.py
@@ -1,0 +1,25 @@
+"""External FHIR import: version detection, stub patients, isolation transaction.
+
+Kept separate from main.py so these pure functions are unit-testable without
+importing the FastAPI application.
+"""
+from __future__ import annotations
+
+# Resource types that were renamed/removed after DSTU2 (strong DSTU2 signal).
+_DSTU2_ONLY_TYPES = {"MedicationOrder", "DeviceUseRequest", "DiagnosticOrder", "BodySite"}
+
+
+def detect_fhir_version(bundle: dict, hint: str | None = None) -> str:
+    """Return "DSTU2" or "R4". Explicit hint wins; otherwise use structural heuristics."""
+    if hint:
+        h = hint.strip().upper()
+        if h in ("DSTU2", "R4"):
+            return h
+    for entry in bundle.get("entry", []):
+        res = entry.get("resource", {})
+        if res.get("resourceType") in _DSTU2_ONLY_TYPES:
+            return "DSTU2"
+        # DSTU2 Observation.category is a single object; R4 makes it an array.
+        if res.get("resourceType") == "Observation" and isinstance(res.get("category"), dict):
+            return "DSTU2"
+    return "R4"

--- a/app/synthea_server/synthea-pyserver/external_import.py
+++ b/app/synthea_server/synthea-pyserver/external_import.py
@@ -6,6 +6,8 @@ importing the FastAPI application.
 from __future__ import annotations
 
 import copy
+import uuid
+from urllib.parse import quote as _urlquote
 
 # Resource types that were renamed/removed after DSTU2 (strong DSTU2 signal).
 _DSTU2_ONLY_TYPES = {"MedicationOrder", "DeviceUseRequest", "DiagnosticOrder", "BodySite"}
@@ -63,3 +65,68 @@ def synthesize_stub_patients(bundle: dict) -> dict:
             "identifier": [{"system": SRC_ID_SYSTEM, "value": pid}],
         }})
     return bundle
+
+
+def _primary_identifier(resource: dict) -> tuple[str, str] | None:
+    """Return (system, value) of the resource's first identifier, or None."""
+    ids = resource.get("identifier")
+    if isinstance(ids, list) and ids:
+        first = ids[0]
+        if isinstance(first, dict) and first.get("system") and first.get("value") is not None:
+            return first["system"], str(first["value"])
+    return None
+
+
+def build_isolation_transaction(bundle: dict) -> tuple[dict, list[dict]]:
+    bundle = copy.deepcopy(bundle)
+    entries = bundle.get("entry", [])
+
+    # 1. Assign a urn:uuid to every entry and index (Type/id) -> urn:uuid.
+    ref_index: dict[str, str] = {}
+    for e in entries:
+        res = e.get("resource", {})
+        e["fullUrl"] = f"urn:uuid:{uuid.uuid4()}"
+        rtype, rid = res.get("resourceType"), res.get("id")
+        if rtype and rid:
+            ref_index[f"{rtype}/{rid}"] = e["fullUrl"]
+
+    # 2. Rewrite in-bundle refs to urn:uuid; collect dangling ones.
+    unresolved: list[dict] = []
+
+    def rewrite(obj, source_label):
+        if isinstance(obj, dict):
+            ref = obj.get("reference")
+            if isinstance(ref, str) and "/" in ref and not ref.startswith("urn:"):
+                if ref in ref_index:
+                    obj["reference"] = ref_index[ref]
+                else:
+                    unresolved.append({"source": source_label, "reference": ref})
+            for v in obj.values():
+                rewrite(v, source_label)
+        elif isinstance(obj, list):
+            for item in obj:
+                rewrite(item, source_label)
+
+    for e in entries:
+        res = e.get("resource", {})
+        source_label = f"{res.get('resourceType')}/{res.get('id')}" if res.get("id") else res.get("resourceType", "?")
+        rewrite(res, source_label)
+
+    # 3. Build POST + ifNoneExist request per entry (idempotent conditional-create).
+    for e in entries:
+        res = e.get("resource", {})
+        rtype = res.get("resourceType")
+        ident = _primary_identifier(res)
+        if ident is None and res.get("id"):
+            ident = (SRC_ID_SYSTEM, str(res["id"]))
+            res.setdefault("identifier", []).append({"system": ident[0], "value": ident[1]})
+        # Server assigns the id; drop the source id so it is never asserted.
+        res.pop("id", None)
+        req = {"method": "POST", "url": rtype}
+        if ident is not None:
+            token = f"{ident[0]}|{ident[1]}"
+            req["ifNoneExist"] = f"identifier={_urlquote(token, safe=':')}"
+        e["request"] = req
+
+    bundle["type"] = "transaction"
+    return bundle, unresolved

--- a/app/synthea_server/synthea-pyserver/external_import.py
+++ b/app/synthea_server/synthea-pyserver/external_import.py
@@ -5,8 +5,12 @@ importing the FastAPI application.
 """
 from __future__ import annotations
 
+import copy
+
 # Resource types that were renamed/removed after DSTU2 (strong DSTU2 signal).
 _DSTU2_ONLY_TYPES = {"MedicationOrder", "DeviceUseRequest", "DiagnosticOrder", "BodySite"}
+
+SRC_ID_SYSTEM = "urn:charm:apple-healthkit-src-id"
 
 
 def detect_fhir_version(bundle: dict, hint: str | None = None) -> str:
@@ -23,3 +27,39 @@ def detect_fhir_version(bundle: dict, hint: str | None = None) -> str:
         if res.get("resourceType") == "Observation" and isinstance(res.get("category"), dict):
             return "DSTU2"
     return "R4"
+
+
+def _iter_references(obj):
+    """Yield every reference string found anywhere in a nested structure."""
+    if isinstance(obj, dict):
+        ref = obj.get("reference")
+        if isinstance(ref, str):
+            yield ref
+        for v in obj.values():
+            yield from _iter_references(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_references(item)
+
+
+def synthesize_stub_patients(bundle: dict) -> dict:
+    """Add a minimal R4 Patient for each Patient/<id> referenced but not contained."""
+    bundle = copy.deepcopy(bundle)
+    entries = bundle.setdefault("entry", [])
+
+    present = {e["resource"]["id"] for e in entries
+               if e.get("resource", {}).get("resourceType") == "Patient" and e["resource"].get("id")}
+
+    referenced = set()
+    for e in entries:
+        for ref in _iter_references(e.get("resource", {})):
+            if ref.startswith("Patient/"):
+                referenced.add(ref[len("Patient/"):])
+
+    for pid in sorted(referenced - present):
+        entries.append({"resource": {
+            "resourceType": "Patient",
+            "id": pid,
+            "identifier": [{"system": SRC_ID_SYSTEM, "value": pid}],
+        }})
+    return bundle

--- a/app/synthea_server/synthea-pyserver/main.py
+++ b/app/synthea_server/synthea-pyserver/main.py
@@ -20,6 +20,8 @@ from timeseries import (
     generate_synthetic_timeseries,
     get_model_info as get_timeseries_model_info,
 )
+import external_import
+CONVERTER_URL = os.environ.get("CONVERTER_URL", "http://fhir-converter:8080")
 import re
 import logging
 import uuid
@@ -2937,7 +2939,8 @@ class ExternalFHIRRequest(BaseModel):
     bundle: dict = Field(..., description="FHIR Bundle containing patient data")
     cohort_id: str = Field("external", description="Cohort identifier for organizing data")
     datatype: str = Field("external", description="Data type classification (external or synthetic)")
-    
+    source_fhir_version: str = Field("R4", description="Source FHIR version: 'R4' (default) or 'DSTU2'")
+
     @field_validator('cohort_id')
     @classmethod
     def validate_cohort_id(cls, v: str) -> str:
@@ -2986,12 +2989,13 @@ async def ingest_external_fhir(request: ExternalFHIRRequest):
 
         logger.info(f"Processing external FHIR bundle for cohort '{request.cohort_id}' with datatype '{request.datatype}'")
         
-        # Prefix patient IDs to prevent conflicts
-        prefixed_bundle = prefix_patient_ids(request.bundle, prefix="ext-")
-        
-        # Convert to transaction bundle for atomic updates
-        transaction_bundle = convert_to_transaction_bundle(prefixed_bundle)
-        
+        # Detect version, convert if DSTU2, synthesize stub patients, isolate ids.
+        transaction_bundle, unresolved_refs = external_import.assemble_external_import(
+            request.bundle, request.source_fhir_version, CONVERTER_URL,
+        )
+        if unresolved_refs:
+            logger.warning(f"{len(unresolved_refs)} unresolved reference(s) in import")
+
         # Apply tags
         tagset = {
             "urn:charm:source": "external",
@@ -3001,17 +3005,14 @@ async def ingest_external_fhir(request: ExternalFHIRRequest):
         }
         apply_tags(transaction_bundle, tagset)
         
-        # Extract patient IDs before posting (for cohort management)
-        patient_ids = set()
-        for entry in transaction_bundle.get("entry", []):
-            resource = entry.get("resource", {})
-            if resource.get("resourceType") == "Patient":
-                patient_id = resource.get("id")
-                if patient_id:
-                    patient_ids.add(patient_id)
-        
-        logger.info(f"Found {len(patient_ids)} patient(s) in bundle: {list(patient_ids)[:5]}{'...' if len(patient_ids) > 5 else ''}")
-        
+        # The transaction drops resource ids (server assigns them via
+        # conditional-create), so cohort patient ids must come from the
+        # response, not the request. Record which entries are Patients by index.
+        patient_entry_indices = [
+            i for i, entry in enumerate(transaction_bundle.get("entry", []))
+            if entry.get("resource", {}).get("resourceType") == "Patient"
+        ]
+
         # Post bundle to HAPI FHIR
         bundle_size = len(json.dumps(transaction_bundle))
         timeout = max(30, min(300, bundle_size / 5000))
@@ -3065,7 +3066,24 @@ async def ingest_external_fhir(request: ExternalFHIRRequest):
             )
         
         logger.info(f"Successfully posted bundle to HAPI FHIR")
-        
+
+        # Pull server-assigned Patient ids from the transaction response.
+        # Each response entry lines up with its request entry by index; a
+        # created/matched resource reports response.location = "Patient/<id>/_history/..".
+        patient_ids = set()
+        try:
+            resp_entries = r.json().get("entry", [])
+            for i in patient_entry_indices:
+                if i < len(resp_entries):
+                    location = resp_entries[i].get("response", {}).get("location", "")
+                    parts = location.split("/")
+                    if len(parts) >= 2 and parts[0] == "Patient" and parts[1]:
+                        patient_ids.add(parts[1])
+        except (ValueError, KeyError, AttributeError) as e:
+            logger.warning(f"Could not parse patient ids from transaction response: {e}")
+
+        logger.info(f"Found {len(patient_ids)} patient(s) in bundle: {list(patient_ids)[:5]}{'...' if len(patient_ids) > 5 else ''}")
+
         # Update cohort Group resource
         if patient_ids:
             try:
@@ -3082,7 +3100,8 @@ async def ingest_external_fhir(request: ExternalFHIRRequest):
             "datatype": request.datatype,
             "patient_count": len(patient_ids),
             "patient_ids": list(patient_ids),
-            "tags_applied": tagset
+            "tags_applied": tagset,
+            "unresolved_references": unresolved_refs
         }
         
     except HTTPException:

--- a/app/synthea_server/synthea-pyserver/main.py
+++ b/app/synthea_server/synthea-pyserver/main.py
@@ -2962,8 +2962,13 @@ async def ingest_external_fhir(request: ExternalFHIRRequest):
     """
     Ingest FHIR bundle from external source (e.g., FHIR-HOSE mobile app).
     
-    This endpoint accepts a FHIR Bundle, prefixes patient IDs to prevent conflicts,
-    applies appropriate tags, and stores the data in HAPI FHIR for cohort management.
+    This endpoint accepts a FHIR Bundle, converts it from DSTU2 to R4 if needed,
+    synthesizes stub Patient resources for any Patient references not present in the
+    bundle, isolates resources from existing data by letting the server assign new
+    ids (moving any incoming id into an identifier used for `ifNoneExist`
+    conditional-create dedup), applies appropriate tags, stores the data in HAPI
+    FHIR for cohort management, and reports any references that could not be
+    resolved.
     
     Args:
         request: ExternalFHIRRequest containing bundle, cohort_id, and datatype
@@ -2990,9 +2995,25 @@ async def ingest_external_fhir(request: ExternalFHIRRequest):
         logger.info(f"Processing external FHIR bundle for cohort '{request.cohort_id}' with datatype '{request.datatype}'")
         
         # Detect version, convert if DSTU2, synthesize stub patients, isolate ids.
-        transaction_bundle, unresolved_refs = external_import.assemble_external_import(
-            request.bundle, request.source_fhir_version, CONVERTER_URL,
-        )
+        # This step calls the FHIR converter sidecar; keep its failures in their
+        # own try/except so they aren't misattributed to HAPI by the outer
+        # requests.Timeout/RequestException handlers below.
+        try:
+            transaction_bundle, unresolved_refs = external_import.assemble_external_import(
+                request.bundle, request.source_fhir_version, CONVERTER_URL,
+            )
+        except external_import.ConversionError as e:
+            logger.error(f"FHIR conversion service error: {str(e)}")
+            raise HTTPException(
+                status_code=502,
+                detail=f"FHIR conversion service error: {str(e)}"
+            )
+        except (requests.Timeout, requests.RequestException) as e:
+            logger.error(f"Error communicating with FHIR conversion service: {str(e)}")
+            raise HTTPException(
+                status_code=502,
+                detail=f"FHIR conversion service error: {str(e)}"
+            )
         if unresolved_refs:
             logger.warning(f"{len(unresolved_refs)} unresolved reference(s) in import")
 

--- a/app/synthea_server/synthea-pyserver/tests/test_external_import.py
+++ b/app/synthea_server/synthea-pyserver/tests/test_external_import.py
@@ -25,3 +25,27 @@ def test_heuristic_defaults_r4():
     bundle = {"resourceType": "Bundle", "entry": [
         {"resource": {"resourceType": "Observation", "category": [{"coding": []}]}}]}
     assert ei.detect_fhir_version(bundle) == "R4"
+
+
+def test_synthesizes_missing_patient():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Observation", "id": "1",
+                      "subject": {"reference": "Patient/100"}}}]}
+    out = ei.synthesize_stub_patients(bundle)
+    patients = [e["resource"] for e in out["entry"]
+                if e["resource"]["resourceType"] == "Patient"]
+    assert len(patients) == 1
+    assert patients[0]["id"] == "100"
+    assert patients[0]["identifier"][0]["system"] == "urn:charm:apple-healthkit-src-id"
+    assert patients[0]["identifier"][0]["value"] == "100"
+
+
+def test_does_not_duplicate_existing_patient():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Patient", "id": "100"}},
+        {"resource": {"resourceType": "Observation", "id": "1",
+                      "subject": {"reference": "Patient/100"}}}]}
+    out = ei.synthesize_stub_patients(bundle)
+    patients = [e["resource"] for e in out["entry"]
+                if e["resource"]["resourceType"] == "Patient"]
+    assert len(patients) == 1

--- a/app/synthea_server/synthea-pyserver/tests/test_external_import.py
+++ b/app/synthea_server/synthea-pyserver/tests/test_external_import.py
@@ -49,3 +49,42 @@ def test_does_not_duplicate_existing_patient():
     patients = [e["resource"] for e in out["entry"]
                 if e["resource"]["resourceType"] == "Patient"]
     assert len(patients) == 1
+
+
+def test_isolation_rewrites_in_bundle_refs_and_reports_dangling():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Patient", "id": "100",
+                      "identifier": [{"system": "urn:charm:apple-healthkit-src-id", "value": "100"}]}},
+        {"resource": {"resourceType": "Observation", "id": "1",
+                      "subject": {"reference": "Patient/100"},
+                      "encounter": {"reference": "Encounter/355"}}},
+    ]}
+    txn, unresolved = ei.build_isolation_transaction(bundle)
+
+    assert txn["type"] == "transaction"
+    # every entry has a urn:uuid fullUrl and a POST request
+    for e in txn["entry"]:
+        assert e["fullUrl"].startswith("urn:uuid:")
+        assert e["request"]["method"] == "POST"
+        assert "ifNoneExist" in e["request"]
+
+    # the in-bundle Patient ref was rewritten to the Patient entry's urn:uuid
+    patient_uuid = next(e["fullUrl"] for e in txn["entry"]
+                        if e["resource"]["resourceType"] == "Patient")
+    obs = next(e["resource"] for e in txn["entry"]
+               if e["resource"]["resourceType"] == "Observation")
+    assert obs["subject"]["reference"] == patient_uuid
+
+    # the dangling Encounter ref is untouched and reported
+    assert obs["encounter"]["reference"] == "Encounter/355"
+    assert {"source": "Observation/1", "reference": "Encounter/355"} in unresolved
+
+
+def test_isolation_synthesizes_identifier_when_absent():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Condition", "id": "7"}}]}
+    txn, _ = ei.build_isolation_transaction(bundle)
+    req = txn["entry"][0]["request"]
+    assert req["method"] == "POST"
+    assert req["url"] == "Condition"
+    assert "identifier=urn:charm:apple-healthkit-src-id%7C7" in req["ifNoneExist"]

--- a/app/synthea_server/synthea-pyserver/tests/test_external_import.py
+++ b/app/synthea_server/synthea-pyserver/tests/test_external_import.py
@@ -88,3 +88,40 @@ def test_isolation_synthesizes_identifier_when_absent():
     assert req["method"] == "POST"
     assert req["url"] == "Condition"
     assert "identifier=urn:charm:apple-healthkit-src-id%7C7" in req["ifNoneExist"]
+
+
+class _FakeResp:
+    def __init__(self, status, payload): self.status_code = status; self._p = payload
+    def json(self): return self._p
+    @property
+    def text(self): import json; return json.dumps(self._p)
+
+
+class _FakeSession:
+    def __init__(self, resp): self.resp = resp; self.calls = []
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.calls.append((url, json)); return self.resp
+
+
+def test_r4_is_passthrough_no_network():
+    sess = _FakeSession(_FakeResp(500, {}))  # would error if called
+    b = {"resourceType": "Bundle", "entry": []}
+    assert ei.convert_bundle(b, "R4", "http://c:8080", session=sess) is b
+    assert sess.calls == []
+
+
+def test_dstu2_calls_converter():
+    r4 = {"resourceType": "Bundle", "type": "collection", "entry": []}
+    sess = _FakeSession(_FakeResp(200, r4))
+    b = {"resourceType": "Bundle", "entry": [{"resource": {"resourceType": "MedicationOrder"}}]}
+    out = ei.convert_bundle(b, "DSTU2", "http://c:8080", session=sess)
+    assert out == r4
+    assert sess.calls[0][0] == "http://c:8080/convert"
+    assert sess.calls[0][1]["sourceVersion"] == "DSTU2"
+
+
+def test_converter_error_raises():
+    sess = _FakeSession(_FakeResp(400, {"resourceType": "OperationOutcome"}))
+    import pytest
+    with pytest.raises(ei.ConversionError):
+        ei.convert_bundle({"resourceType": "Bundle"}, "DSTU2", "http://c:8080", session=sess)

--- a/app/synthea_server/synthea-pyserver/tests/test_external_import.py
+++ b/app/synthea_server/synthea-pyserver/tests/test_external_import.py
@@ -90,6 +90,17 @@ def test_isolation_synthesizes_identifier_when_absent():
     assert "identifier=urn:charm:apple-healthkit-src-id%7C7" in req["ifNoneExist"]
 
 
+def test_assemble_external_import_end_to_end_r4():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Observation", "id": "1",
+                      "subject": {"reference": "Patient/100"}}}]}
+    txn, unresolved = ei.assemble_external_import(bundle, "R4", "http://c:8080")
+    assert txn["type"] == "transaction"
+    types = {e["resource"]["resourceType"] for e in txn["entry"]}
+    assert "Patient" in types            # stub synthesized
+    assert unresolved == []              # Patient/100 now resolves in-bundle
+
+
 class _FakeResp:
     def __init__(self, status, payload): self.status_code = status; self._p = payload
     def json(self): return self._p

--- a/app/synthea_server/synthea-pyserver/tests/test_external_import.py
+++ b/app/synthea_server/synthea-pyserver/tests/test_external_import.py
@@ -1,0 +1,27 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import external_import as ei
+
+
+def test_explicit_hint_wins():
+    assert ei.detect_fhir_version({"resourceType": "Bundle", "entry": []}, hint="dstu2") == "DSTU2"
+    assert ei.detect_fhir_version({"resourceType": "Bundle", "entry": []}, hint="R4") == "R4"
+
+
+def test_heuristic_detects_dstu2_medicationorder():
+    bundle = {"resourceType": "Bundle", "entry": [
+        {"resource": {"resourceType": "MedicationOrder", "id": "1"}}]}
+    assert ei.detect_fhir_version(bundle) == "DSTU2"
+
+
+def test_heuristic_detects_dstu2_category_object():
+    bundle = {"resourceType": "Bundle", "entry": [
+        {"resource": {"resourceType": "Observation",
+                      "category": {"coding": [{"code": "laboratory"}]}}}]}
+    assert ei.detect_fhir_version(bundle) == "DSTU2"
+
+
+def test_heuristic_defaults_r4():
+    bundle = {"resourceType": "Bundle", "entry": [
+        {"resource": {"resourceType": "Observation", "category": [{"coding": []}]}}]}
+    assert ei.detect_fhir_version(bundle) == "R4"

--- a/app/synthea_server/test_fixtures/apple_healthkit_dstu2_a.json
+++ b/app/synthea_server/test_fixtures/apple_healthkit_dstu2_a.json
@@ -1,0 +1,600 @@
+{
+  "entry" : [
+    {
+      "resource" : {
+        "asserter" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "category" : {
+          "coding" : [
+            {
+              "code" : "diagnosis",
+              "system" : "http:\/\/hl7.org\/fhir\/condition-category"
+            }
+          ]
+        },
+        "clinicalStatus" : "active",
+        "code" : {
+          "coding" : [
+            {
+              "code" : "367498001",
+              "display" : "Seasonal allergic rhinitis",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Seasonal Allergic Rhinitis"
+        },
+        "dateRecorded" : "2019-01-02",
+        "id" : "2",
+        "notes" : "Worse when visiting family in NC during the spring",
+        "onsetDateTime" : "2001-05-12",
+        "patient" : {
+          "reference" : "Patient\/1"
+        },
+        "resourceType" : "Condition",
+        "verificationStatus" : "confirmed"
+      }
+    },
+    {
+      "resource" : {
+        "asserter" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "category" : {
+          "coding" : [
+            {
+              "code" : "diagnosis",
+              "system" : "http:\/\/hl7.org\/fhir\/condition-category"
+            }
+          ]
+        },
+        "clinicalStatus" : "active",
+        "code" : {
+          "coding" : [
+            {
+              "code" : "195967001",
+              "display" : "Asthma",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Asthma"
+        },
+        "dateRecorded" : "2019-01-02",
+        "id" : "1",
+        "notes" : "2 brief hospitalizations when a child, symptoms much improved as an adult",
+        "onsetDateTime" : "1992-09-09",
+        "patient" : {
+          "display" : "Salinas, Candace",
+          "reference" : "Patient\/1"
+        },
+        "resourceType" : "Condition",
+        "verificationStatus" : "confirmed"
+      }
+    },
+    {
+      "resource" : {
+        "asserter" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "category" : {
+          "coding" : [
+            {
+              "code" : "diagnosis",
+              "system" : "http:\/\/hl7.org\/fhir\/condition-category"
+            }
+          ]
+        },
+        "clinicalStatus" : "active",
+        "code" : {
+          "coding" : [
+            {
+              "code" : "36971009",
+              "display" : "Sinusitis (disorder)",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Sinusitis"
+        },
+        "dateRecorded" : "2023-11-25",
+        "id" : "4",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        },
+        "resourceType" : "Condition",
+        "verificationStatus" : "confirmed"
+      }
+    },
+    {
+      "resource" : {
+        "dateWritten" : "2001-02-26",
+        "dosageInstruction" : [
+          {
+            "text" : "Once Daily"
+          }
+        ],
+        "id" : "18",
+        "medicationCodeableConcept" : {
+          "coding" : [
+            {
+              "code" : "316167",
+              "display" : "Loratadine 10 MG Oral Capsule",
+              "system" : "http:\/\/www.nlm.nih.gov\/research\/umls\/rxnorm\/"
+            }
+          ],
+          "text" : "Loratadine 10 mg"
+        },
+        "note" : "You only need to take this medication during pollen season",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        },
+        "prescriber" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "resourceType" : "MedicationOrder",
+        "status" : "active"
+      }
+    },
+    {
+      "resource" : {
+        "dateWritten" : "1992-10-11",
+        "dosageInstruction" : [
+          {
+            "text" : "2 puffs every 2-4 hours"
+          }
+        ],
+        "id" : "24",
+        "medicationCodeableConcept" : {
+          "coding" : [
+            {
+              "code" : "329498",
+              "system" : "http:\/\/www.nlm.nih.gov\/research\/umls\/rxnorm\/"
+            }
+          ],
+          "text" : "Albuterol HFA 90 mcg"
+        },
+        "note" : "Please let me know if you need to use this more than three times per day",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        },
+        "prescriber" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "resourceType" : "MedicationOrder",
+        "status" : "active"
+      }
+    },
+    {
+      "resource" : {
+        "id" : "2",
+        "onset" : "1995",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        },
+        "reaction" : [
+          {
+            "manifestation" : [
+              {
+                "text" : "Wheezing"
+              }
+            ],
+            "onset" : "2022-02-17",
+            "severity" : "severe"
+          }
+        ],
+        "recordedDate" : "2022-02-18",
+        "resourceType" : "AllergyIntolerance",
+        "status" : "active",
+        "substance" : {
+          "coding" : [
+            {
+              "code" : "256349002",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Peanuts"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "code" : {
+          "coding" : [
+            {
+              "code" : "239426007",
+              "display" : "Repair of anterior cruciate ligament of knee joint (procedure)",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "ACL repair"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/2089375"
+        },
+        "id" : "10",
+        "performedDateTime" : "2021-06-09",
+        "resourceType" : "Procedure",
+        "status" : "completed",
+        "subject" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "code" : {
+          "coding" : [
+            {
+              "code" : "80146002",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Appendectomy"
+        },
+        "id" : "9",
+        "performedDateTime" : "2014-05-25",
+        "resourceType" : "Procedure",
+        "status" : "completed",
+        "subject" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "2085-9",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Cholesterol HDL"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "21",
+        "issued" : "2024-02-18T00:00:00Z",
+        "referenceRange" : [
+          {
+            "high" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 59
+            },
+            "text" : "35 to 59 mg\/dL"
+          }
+        ],
+        "resourceType" : "Observation",
+        "status" : "final",
+        "valueQuantity" : {
+          "code" : "mg\/dL",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "mg\/dL",
+          "value" : 95.5
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "58410-2",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "CBC panel - Blood by Automated count"
+        },
+        "component" : [
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "6690-2",
+                  "display" : "Leukocytes [#\/volume] in Blood by Automated count",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Leukocytes [#\/volume] in Blood by Automated count"
+            },
+            "valueQuantity" : {
+              "code" : "10*3\/uL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "10*3\/uL",
+              "value" : 111
+            }
+          },
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "789-8",
+                  "display" : "Erythrocytes [#\/volume] in Blood by Automated count",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Erythrocytes [#\/volume] in Blood by Automated count"
+            },
+            "valueQuantity" : {
+              "code" : "10*6\/uL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "10*6\/uL",
+              "value" : 222
+            }
+          },
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "777-3",
+                  "display" : "Platelets [#\/volume] in Blood by Automated count",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Platelets [#\/volume] in Blood by Automated count"
+            },
+            "valueQuantity" : {
+              "code" : "10*3\/uL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "10*3\/uL",
+              "value" : 333
+            }
+          },
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "718-7",
+                  "display" : "Hemoglobin [Mass\/volume] in Blood",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Hemoglobin [Mass\/volume] in Blood"
+            },
+            "referenceRange" : [
+              {
+                "high" : {
+                  "code" : "g\/dL",
+                  "system" : "http:\/\/unitsofmeasure.org",
+                  "unit" : "g\/dL",
+                  "value" : 400
+                },
+                "low" : {
+                  "code" : "g\/dL",
+                  "system" : "http:\/\/unitsofmeasure.org",
+                  "unit" : "g\/dL",
+                  "value" : 500
+                },
+                "text" : "400 to 500 g\/dL"
+              }
+            ],
+            "valueQuantity" : {
+              "code" : "g\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "g\/dL",
+              "value" : 444
+            }
+          }
+        ],
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "2634785",
+        "issued" : "2023-10-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/1"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "3043-7",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Triglycerides"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "12",
+        "issued" : "2024-02-18T00:00:00Z",
+        "referenceRange" : [
+          {
+            "high" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 250
+            },
+            "low" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 10
+            },
+            "text" : "10 to 250 mg\/dL"
+          }
+        ],
+        "resourceType" : "Observation",
+        "status" : "final",
+        "valueQuantity" : {
+          "code" : "mg\/dL",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "mg\/dL",
+          "value" : 86
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "39156-5",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "BMI-body mass index"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "4",
+        "issued" : "2024-02-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/1"
+        },
+        "valueQuantity" : {
+          "code" : "kg\/m^2",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "kg\/m^2",
+          "value" : 26.199999999999999
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "8867-4",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Pulse"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "7",
+        "issued" : "2024-02-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/1"
+        },
+        "valueQuantity" : {
+          "code" : "\/min",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "\/min",
+          "value" : 77
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "8310-5",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Temperature"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "14",
+        "issued" : "2024-02-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/1"
+        },
+        "valueQuantity" : {
+          "code" : "Cel",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "Cel",
+          "value" : 37.600000000000001
+        }
+      }
+    }
+  ],
+  "meta" : {
+    "tag" : [
+      {
+        "code" : "1.0.2",
+        "system" : "http:\/\/hl7.org\/fhir\/FHIR-version"
+      }
+    ]
+  },
+  "resourceType" : "Bundle",
+  "timestamp" : "2026-08-20T17:11:35Z",
+  "type" : "collection"
+}

--- a/app/synthea_server/test_fixtures/apple_healthkit_dstu2_b.json
+++ b/app/synthea_server/test_fixtures/apple_healthkit_dstu2_b.json
@@ -1,0 +1,1220 @@
+{
+  "entry" : [
+    {
+      "resource" : {
+        "dateWritten" : "2023-10-20",
+        "dosageInstruction" : [
+          {
+            "text" : "One tablet by mouth daily",
+            "timing" : {
+              "repeat" : {
+                "boundsPeriod" : {
+                  "start" : "2023-10-20"
+                }
+              }
+            }
+          }
+        ],
+        "id" : "13",
+        "medicationCodeableConcept" : {
+          "coding" : [
+            {
+              "system" : "http:\/\/www.nlm.nih.gov\/research\/umls\/rxnorm\/"
+            }
+          ],
+          "text" : "Prenatal vitamins (with folate)"
+        },
+        "note" : "Over the counter",
+        "patient" : {
+          "reference" : "Patient\/100"
+        },
+        "prescriber" : {
+          "display" : "Altick Kelly",
+          "reference" : "Practitioner\/8"
+        },
+        "resourceType" : "MedicationOrder",
+        "status" : "active"
+      }
+    },
+    {
+      "resource" : {
+        "id" : "2",
+        "onset" : "2010-04-12",
+        "patient" : {
+          "reference" : "Patient\/100"
+        },
+        "reaction" : [
+          {
+            "manifestation" : [
+              {
+                "text" : "Rash"
+              }
+            ],
+            "onset" : "2024-02-17T15:23:00+05:00",
+            "severity" : "mild"
+          }
+        ],
+        "resourceType" : "AllergyIntolerance",
+        "status" : "confirmed",
+        "substance" : {
+          "coding" : [
+            {
+              "code" : "373270004",
+              "display" : "Penicillin -class of antibiotic- (substance)",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Penicillin"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "code" : {
+          "coding" : [
+            {
+              "code" : "420052009",
+              "display" : "Ultrasound scan of lower abdomen (procedure)",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Ultrasound Abdomen"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "223468",
+        "performedDateTime" : "2023-10-18",
+        "performer" : [
+          {
+            "actor" : {
+              "display" : "Altick Kelly, MD",
+              "reference" : "Practitioner\/8"
+            },
+            "role" : {
+              "coding" : [
+                {
+                  "code" : "83685006",
+                  "display" : "Gynecologist",
+                  "system" : "http:\/\/snomed.info\/sct"
+                }
+              ]
+            }
+          }
+        ],
+        "resourceType" : "Procedure",
+        "status" : "completed",
+        "subject" : {
+          "reference" : "Patient\/1"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "date" : "2023-10-18",
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "19",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/100"
+        },
+        "reported" : false,
+        "requester" : {
+          "display" : "Altick Kelly",
+          "reference" : "Practitioner\/8"
+        },
+        "resourceType" : "Immunization",
+        "status" : "completed",
+        "vaccineCode" : {
+          "coding" : [
+            {
+              "code" : "115",
+              "system" : "CVX"
+            }
+          ],
+          "text" : "DTaP"
+        },
+        "wasNotGiven" : false
+      }
+    },
+    {
+      "resource" : {
+        "date" : "2023-10-18",
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "3",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/100"
+        },
+        "reported" : false,
+        "requester" : {
+          "display" : "Altick Kelly",
+          "reference" : "Practitioner\/8"
+        },
+        "resourceType" : "Immunization",
+        "status" : "completed",
+        "vaccineCode" : {
+          "coding" : [
+            {
+              "code" : "135",
+              "system" : "CVX"
+            }
+          ],
+          "text" : "Influenza"
+        },
+        "wasNotGiven" : false
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "2089-1",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "LDL-cholesterol"
+        },
+        "id" : "1",
+        "issued" : "2023-10-18T00:00:00Z",
+        "referenceRange" : [
+          {
+            "high" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 178
+            },
+            "low" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 50
+            },
+            "text" : "50 to 178 mg\/dL"
+          }
+        ],
+        "resourceType" : "Observation",
+        "status" : "final",
+        "valueQuantity" : {
+          "code" : "mg\/dL",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "mg\/dL",
+          "value" : 113.3
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "2093-3",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Total cholesterol"
+        },
+        "id" : "11",
+        "issued" : "2023-10-18T00:00:00Z",
+        "referenceRange" : [
+          {
+            "high" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 220
+            },
+            "low" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 120
+            },
+            "text" : "120 to 220 mg\/dL"
+          }
+        ],
+        "resourceType" : "Observation",
+        "status" : "final",
+        "valueQuantity" : {
+          "code" : "mg\/dL",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "mg\/dL",
+          "value" : 184
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "2339-0",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Blood Glucose"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "2738664",
+        "issued" : "2023-10-18T00:00:00Z",
+        "referenceRange" : [
+          {
+            "high" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 100
+            },
+            "low" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 61
+            },
+            "text" : "61-100 mg\/dL"
+          }
+        ],
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/100"
+        },
+        "valueQuantity" : {
+          "code" : "mg\/dL",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "mg\/dL",
+          "value" : 60
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "8867-4",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Pulse"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "72354778",
+        "issued" : "2023-10-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/100"
+        },
+        "valueQuantity" : {
+          "code" : "\/min",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "\/min",
+          "value" : 72
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "8302-2",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Height"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "162467",
+        "issued" : "2023-10-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/100"
+        },
+        "valueQuantity" : {
+          "code" : "cm",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "cm",
+          "value" : 164
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "8310-5",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Temperature"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "1423546",
+        "issued" : "2023-10-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/100"
+        },
+        "valueQuantity" : {
+          "code" : "Cel",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "Cel",
+          "value" : 37.399999999999999
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "55284-4",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "BP-blood pressure"
+        },
+        "component" : [
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "8480-6",
+                  "display" : "Systolic blood pressure",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Systolic blood pressure"
+            },
+            "valueQuantity" : {
+              "code" : "mm[Hg]",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mm[Hg]",
+              "value" : 110
+            }
+          },
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "8462-4",
+                  "display" : "Diastolic blood pressure",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Diastolic blood pressure"
+            },
+            "valueQuantity" : {
+              "code" : "mm[Hg]",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mm[Hg]",
+              "value" : 70
+            }
+          }
+        ],
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "2634785",
+        "issued" : "2023-10-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/100"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "9279-1",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Respiratory Rate"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "13247837",
+        "issued" : "2023-10-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/100"
+        },
+        "valueQuantity" : {
+          "code" : "\/min",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "\/min",
+          "value" : 22
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "39156-5",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "BMI-body mass index"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "43465",
+        "issued" : "2023-10-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/100"
+        },
+        "valueQuantity" : {
+          "code" : "kg\/m^2",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "kg\/m^2",
+          "value" : 26.600000000000001
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "29463-7",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Weight"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/129837645"
+        },
+        "id" : "15458",
+        "issued" : "2023-10-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/100"
+        },
+        "valueQuantity" : {
+          "code" : "[lb_av]",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "[lb_av]",
+          "value" : 155
+        }
+      }
+    },
+    {
+      "resource" : {
+        "asserter" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "category" : {
+          "coding" : [
+            {
+              "code" : "diagnosis",
+              "system" : "http:\/\/hl7.org\/fhir\/condition-category"
+            }
+          ]
+        },
+        "clinicalStatus" : "active",
+        "code" : {
+          "coding" : [
+            {
+              "code" : "367498001",
+              "display" : "Seasonal allergic rhinitis",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Seasonal Allergic Rhinitis"
+        },
+        "dateRecorded" : "2019-01-02",
+        "id" : "2",
+        "notes" : "Worse when visiting family in NC during the spring",
+        "onsetDateTime" : "2001-05-12",
+        "patient" : {
+          "reference" : "Patient\/1"
+        },
+        "resourceType" : "Condition",
+        "verificationStatus" : "confirmed"
+      }
+    },
+    {
+      "resource" : {
+        "asserter" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "category" : {
+          "coding" : [
+            {
+              "code" : "diagnosis",
+              "system" : "http:\/\/hl7.org\/fhir\/condition-category"
+            }
+          ]
+        },
+        "clinicalStatus" : "active",
+        "code" : {
+          "coding" : [
+            {
+              "code" : "195967001",
+              "display" : "Asthma",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Asthma"
+        },
+        "dateRecorded" : "2019-01-02",
+        "id" : "1",
+        "notes" : "2 brief hospitalizations when a child, symptoms much improved as an adult",
+        "onsetDateTime" : "1992-09-09",
+        "patient" : {
+          "display" : "Salinas, Candace",
+          "reference" : "Patient\/1"
+        },
+        "resourceType" : "Condition",
+        "verificationStatus" : "confirmed"
+      }
+    },
+    {
+      "resource" : {
+        "asserter" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "category" : {
+          "coding" : [
+            {
+              "code" : "diagnosis",
+              "system" : "http:\/\/hl7.org\/fhir\/condition-category"
+            }
+          ]
+        },
+        "clinicalStatus" : "active",
+        "code" : {
+          "coding" : [
+            {
+              "code" : "36971009",
+              "display" : "Sinusitis (disorder)",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Sinusitis"
+        },
+        "dateRecorded" : "2023-11-25",
+        "id" : "4",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        },
+        "resourceType" : "Condition",
+        "verificationStatus" : "confirmed"
+      }
+    },
+    {
+      "resource" : {
+        "dateWritten" : "2001-02-26",
+        "dosageInstruction" : [
+          {
+            "text" : "Once Daily"
+          }
+        ],
+        "id" : "18",
+        "medicationCodeableConcept" : {
+          "coding" : [
+            {
+              "code" : "316167",
+              "display" : "Loratadine 10 MG Oral Capsule",
+              "system" : "http:\/\/www.nlm.nih.gov\/research\/umls\/rxnorm\/"
+            }
+          ],
+          "text" : "Loratadine 10 mg"
+        },
+        "note" : "You only need to take this medication during pollen season",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        },
+        "prescriber" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "resourceType" : "MedicationOrder",
+        "status" : "active"
+      }
+    },
+    {
+      "resource" : {
+        "dateWritten" : "1992-10-11",
+        "dosageInstruction" : [
+          {
+            "text" : "2 puffs every 2-4 hours"
+          }
+        ],
+        "id" : "24",
+        "medicationCodeableConcept" : {
+          "coding" : [
+            {
+              "code" : "329498",
+              "system" : "http:\/\/www.nlm.nih.gov\/research\/umls\/rxnorm\/"
+            }
+          ],
+          "text" : "Albuterol HFA 90 mcg"
+        },
+        "note" : "Please let me know if you need to use this more than three times per day",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        },
+        "prescriber" : {
+          "display" : "Daren Estrada",
+          "reference" : "Practitioner\/20"
+        },
+        "resourceType" : "MedicationOrder",
+        "status" : "active"
+      }
+    },
+    {
+      "resource" : {
+        "id" : "2",
+        "onset" : "1995",
+        "patient" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        },
+        "reaction" : [
+          {
+            "manifestation" : [
+              {
+                "text" : "Wheezing"
+              }
+            ],
+            "onset" : "2022-02-17",
+            "severity" : "severe"
+          }
+        ],
+        "recordedDate" : "2022-02-18",
+        "resourceType" : "AllergyIntolerance",
+        "status" : "active",
+        "substance" : {
+          "coding" : [
+            {
+              "code" : "256349002",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Peanuts"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "code" : {
+          "coding" : [
+            {
+              "code" : "239426007",
+              "display" : "Repair of anterior cruciate ligament of knee joint (procedure)",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "ACL repair"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/2089375"
+        },
+        "id" : "10",
+        "performedDateTime" : "2021-06-09",
+        "resourceType" : "Procedure",
+        "status" : "completed",
+        "subject" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "code" : {
+          "coding" : [
+            {
+              "code" : "80146002",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Appendectomy"
+        },
+        "id" : "9",
+        "performedDateTime" : "2014-05-25",
+        "resourceType" : "Procedure",
+        "status" : "completed",
+        "subject" : {
+          "display" : "Candace Salinas",
+          "reference" : "Patient\/1"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "2085-9",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Cholesterol HDL"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "21",
+        "issued" : "2024-02-18T00:00:00Z",
+        "referenceRange" : [
+          {
+            "high" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 59
+            },
+            "text" : "35 to 59 mg\/dL"
+          }
+        ],
+        "resourceType" : "Observation",
+        "status" : "final",
+        "valueQuantity" : {
+          "code" : "mg\/dL",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "mg\/dL",
+          "value" : 95.5
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "58410-2",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "CBC panel - Blood by Automated count"
+        },
+        "component" : [
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "6690-2",
+                  "display" : "Leukocytes [#\/volume] in Blood by Automated count",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Leukocytes [#\/volume] in Blood by Automated count"
+            },
+            "valueQuantity" : {
+              "code" : "10*3\/uL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "10*3\/uL",
+              "value" : 111
+            }
+          },
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "789-8",
+                  "display" : "Erythrocytes [#\/volume] in Blood by Automated count",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Erythrocytes [#\/volume] in Blood by Automated count"
+            },
+            "valueQuantity" : {
+              "code" : "10*6\/uL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "10*6\/uL",
+              "value" : 222
+            }
+          },
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "777-3",
+                  "display" : "Platelets [#\/volume] in Blood by Automated count",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Platelets [#\/volume] in Blood by Automated count"
+            },
+            "valueQuantity" : {
+              "code" : "10*3\/uL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "10*3\/uL",
+              "value" : 333
+            }
+          },
+          {
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "718-7",
+                  "display" : "Hemoglobin [Mass\/volume] in Blood",
+                  "system" : "http:\/\/loinc.org"
+                }
+              ],
+              "text" : "Hemoglobin [Mass\/volume] in Blood"
+            },
+            "referenceRange" : [
+              {
+                "high" : {
+                  "code" : "g\/dL",
+                  "system" : "http:\/\/unitsofmeasure.org",
+                  "unit" : "g\/dL",
+                  "value" : 400
+                },
+                "low" : {
+                  "code" : "g\/dL",
+                  "system" : "http:\/\/unitsofmeasure.org",
+                  "unit" : "g\/dL",
+                  "value" : 500
+                },
+                "text" : "400 to 500 g\/dL"
+              }
+            ],
+            "valueQuantity" : {
+              "code" : "g\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "g\/dL",
+              "value" : 444
+            }
+          }
+        ],
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "2634785",
+        "issued" : "2023-10-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/1"
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "3043-7",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Triglycerides"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "12",
+        "issued" : "2024-02-18T00:00:00Z",
+        "referenceRange" : [
+          {
+            "high" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 250
+            },
+            "low" : {
+              "code" : "mg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "mg\/dL",
+              "value" : 10
+            },
+            "text" : "10 to 250 mg\/dL"
+          }
+        ],
+        "resourceType" : "Observation",
+        "status" : "final",
+        "valueQuantity" : {
+          "code" : "mg\/dL",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "mg\/dL",
+          "value" : 86
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "39156-5",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "BMI-body mass index"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "4",
+        "issued" : "2024-02-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/1"
+        },
+        "valueQuantity" : {
+          "code" : "kg\/m^2",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "kg\/m^2",
+          "value" : 26.199999999999999
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "8867-4",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Pulse"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "7",
+        "issued" : "2024-02-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/1"
+        },
+        "valueQuantity" : {
+          "code" : "\/min",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "\/min",
+          "value" : 77
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "vital-signs",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Vital Signs"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "8310-5",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Temperature"
+        },
+        "encounter" : {
+          "reference" : "Encounter\/355"
+        },
+        "id" : "14",
+        "issued" : "2024-02-18T00:00:00Z",
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/1"
+        },
+        "valueQuantity" : {
+          "code" : "Cel",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "Cel",
+          "value" : 37.600000000000001
+        }
+      }
+    }
+  ],
+  "meta" : {
+    "tag" : [
+      {
+        "code" : "1.0.2",
+        "system" : "http:\/\/hl7.org\/fhir\/FHIR-version"
+      }
+    ]
+  },
+  "resourceType" : "Bundle",
+  "timestamp" : "2026-08-20T17:13:05Z",
+  "type" : "collection"
+}

--- a/app/synthea_server/test_fixtures/apple_healthkit_dstu2_c.json
+++ b/app/synthea_server/test_fixtures/apple_healthkit_dstu2_c.json
@@ -1,0 +1,190 @@
+{
+  "entry" : [
+    {
+      "resource" : {
+        "asserter" : {
+          "display" : "Troy Monken",
+          "reference" : "Practitioner\/23"
+        },
+        "category" : {
+          "coding" : [
+            {
+              "code" : "diagnosis",
+              "system" : "http:\/\/hl7.org\/fhir\/condition-category"
+            }
+          ]
+        },
+        "clinicalStatus" : "active",
+        "code" : {
+          "coding" : [
+            {
+              "code" : "40930008",
+              "system" : "http:\/\/snomed.info\/sct"
+            }
+          ],
+          "text" : "Hypothyroidism"
+        },
+        "dateRecorded" : "2014-10-12",
+        "id" : "42467",
+        "patient" : {
+          "reference" : "Patient\/19035"
+        },
+        "resourceType" : "Condition",
+        "verificationStatus" : "confirmed"
+      }
+    },
+    {
+      "resource" : {
+        "dateWritten" : "2015-01-03T00:00:00-08:00",
+        "dosageInstruction" : [
+          {
+            "text" : "Once Daily",
+            "timing" : {
+              "repeat" : {
+                "boundsPeriod" : {
+                  "start" : "2015-01-03"
+                }
+              }
+            }
+          }
+        ],
+        "id" : "23535",
+        "medicationCodeableConcept" : {
+          "coding" : [
+            {
+              "code" : "903736",
+              "system" : "http:\/\/www.nlm.nih.gov\/research\/umls\/rxnorm\/"
+            }
+          ],
+          "text" : "Levothyroxine 75 mcg"
+        },
+        "note" : "Take on empty stomach at least 30 minutes before eating",
+        "patient" : {
+          "display" : "Salinas, Candace",
+          "reference" : "Patient\/19035"
+        },
+        "prescriber" : {
+          "display" : "Troy Monken",
+          "reference" : "Practitioner\/24763"
+        },
+        "resourceType" : "MedicationOrder",
+        "status" : "active"
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "3016-3",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "TSH"
+        },
+        "id" : "22",
+        "issued" : "2014-09-04T14:15:00+06:00",
+        "referenceRange" : [
+          {
+            "high" : {
+              "code" : "µU\/mL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "µU\/mL",
+              "value" : 5.5
+            },
+            "low" : {
+              "code" : "µU\/mL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "µU\/mL",
+              "value" : 0.34999999999999998
+            },
+            "text" : "0.350 to 5.500 µU\/mL"
+          }
+        ],
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/19035"
+        },
+        "valueQuantity" : {
+          "code" : "µU\/mL",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "µU\/mL",
+          "value" : 3.915
+        }
+      }
+    },
+    {
+      "resource" : {
+        "category" : {
+          "coding" : [
+            {
+              "code" : "laboratory",
+              "system" : "http:\/\/hl7.org\/fhir\/observation-category"
+            }
+          ],
+          "text" : "Laboratory"
+        },
+        "code" : {
+          "coding" : [
+            {
+              "code" : "3026-2",
+              "system" : "http:\/\/loinc.org"
+            }
+          ],
+          "text" : "Thyroxine (T4)"
+        },
+        "id" : "6",
+        "issued" : "2014-09-04T14:15:00+06:00",
+        "referenceRange" : [
+          {
+            "high" : {
+              "code" : "µg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "µg\/dL",
+              "value" : 12
+            },
+            "low" : {
+              "code" : "µg\/dL",
+              "system" : "http:\/\/unitsofmeasure.org",
+              "unit" : "µg\/dL",
+              "value" : 4.5
+            },
+            "text" : "4.5 - 12 µg\/dL"
+          }
+        ],
+        "resourceType" : "Observation",
+        "status" : "final",
+        "subject" : {
+          "reference" : "Patient\/19035"
+        },
+        "valueQuantity" : {
+          "code" : "µg\/dL",
+          "system" : "http:\/\/unitsofmeasure.org",
+          "unit" : "µg\/dL",
+          "value" : 9.8000000000000007
+        }
+      }
+    }
+  ],
+  "meta" : {
+    "tag" : [
+      {
+        "code" : "1.0.2",
+        "system" : "http:\/\/hl7.org\/fhir\/FHIR-version"
+      }
+    ]
+  },
+  "resourceType" : "Bundle",
+  "timestamp" : "2026-08-20T17:14:43Z",
+  "type" : "collection"
+}

--- a/app/vueapp_guided/src/flows/IngestionFlow.vue
+++ b/app/vueapp_guided/src/flows/IngestionFlow.vue
@@ -126,8 +126,8 @@
       </div>
 
       <p class="muted" style="margin-top: 0.8rem">
-        All patient IDs will be prefixed with <code>ext-</code> automatically to prevent
-        collisions with synthetic data.
+        Imported records are isolated with server-assigned IDs, so they can't collide
+        with existing synthetic or previously imported data.
       </p>
     </template>
 

--- a/ci/external_fhir_ingestion_validation.sh
+++ b/ci/external_fhir_ingestion_validation.sh
@@ -169,19 +169,19 @@ if ! echo "$REQUEST_BODY" | jq -e --arg cohort_id "$cohort_id" '
   exit 1
 fi
 
-prefixed_patient_id="$(echo "$REQUEST_BODY" | jq -r '.patient_ids[0] // empty')"
-if [ -z "$prefixed_patient_id" ] || [[ "$prefixed_patient_id" != ext-* ]]; then
-  error "Expected prefixed patient id starting with ext-, got '${prefixed_patient_id}'"
+server_patient_id="$(echo "$REQUEST_BODY" | jq -r '.patient_ids[0] // empty')"
+if [ -z "$server_patient_id" ]; then
+  error "Expected a non-empty server-assigned patient id, got '${server_patient_id}'"
   exit 1
 fi
 
-log "Validating patient and cohort resources in HAPI for ${prefixed_patient_id}"
-patient_json="$(curl -fsS "${HAPI_BASE_URL}/Patient/${prefixed_patient_id}")"
+log "Validating patient and cohort resources in HAPI for ${server_patient_id}"
+patient_json="$(curl -fsS "${HAPI_BASE_URL}/Patient/${server_patient_id}")"
 if ! echo "$patient_json" | jq -e '
   .resourceType == "Patient"
   and (.id | type == "string" and length > 0)
 ' >/dev/null; then
-  error "HAPI patient validation failed for ${prefixed_patient_id}: ${patient_json}"
+  error "HAPI patient validation failed for ${server_patient_id}: ${patient_json}"
   exit 1
 fi
 
@@ -189,26 +189,26 @@ if ! echo "$patient_json" | jq -e --arg cohort_id "$cohort_id" '
   any(.meta.tag[]?; .system == "urn:charm:source" and .code == "external")
   and any(.meta.tag[]?; .system == "urn:charm:cohort" and .code == $cohort_id)
 ' >/dev/null; then
-  error "Expected CHARM tags not found on patient ${prefixed_patient_id}"
+  error "Expected CHARM tags not found on patient ${server_patient_id}"
   exit 1
 fi
 
 group_json="$(curl -fsS "${HAPI_BASE_URL}/Group/${cohort_id}")"
-if ! echo "$group_json" | jq -e --arg patient_ref "Patient/${prefixed_patient_id}" '
+if ! echo "$group_json" | jq -e --arg patient_ref "Patient/${server_patient_id}" '
   .resourceType == "Group"
   and any(.member[]?; .entity.reference == $patient_ref)
 ' >/dev/null; then
-  error "Group/${cohort_id} missing expected patient member ${prefixed_patient_id}"
+  error "Group/${cohort_id} missing expected patient member ${server_patient_id}"
   exit 1
 fi
 
-obs_count_before="$(curl -fsS "${HAPI_BASE_URL}/Observation?subject=Patient/${prefixed_patient_id}&_summary=count" | jq -r '.total // 0')"
+obs_count_before="$(curl -fsS "${HAPI_BASE_URL}/Observation?subject=Patient/${server_patient_id}&_summary=count" | jq -r '.total // 0')"
 if ! [[ "$obs_count_before" =~ ^[0-9]+$ ]] || [ "$obs_count_before" -lt 1 ]; then
-  error "Invalid initial observation count for ${prefixed_patient_id}: ${obs_count_before}"
+  error "Invalid initial observation count for ${server_patient_id}: ${obs_count_before}"
   exit 1
 fi
 
-log "Re-ingesting updated bundle for ${prefixed_patient_id}"
+log "Re-ingesting updated bundle for ${server_patient_id}"
 request_json "POST" "${SYNTHEA_BASE_URL}/ingest-external-fhir" "$(jq -nc \
   --argjson bundle "$bundle_two" \
   --arg cohort_id "$cohort_id" \
@@ -220,13 +220,13 @@ if [ "$REQUEST_STATUS" != "200" ]; then
   exit 1
 fi
 
-patient_duplicate_count="$(curl -fsS "${HAPI_BASE_URL}/Patient?_id=${prefixed_patient_id}&_summary=count" | jq -r '.total // 0')"
+patient_duplicate_count="$(curl -fsS "${HAPI_BASE_URL}/Patient?_id=${server_patient_id}&_summary=count" | jq -r '.total // 0')"
 if ! [[ "$patient_duplicate_count" =~ ^[0-9]+$ ]] || [ "$patient_duplicate_count" -ne 1 ]; then
   error "Expected exactly one patient after re-ingest, got ${patient_duplicate_count}"
   exit 1
 fi
 
-obs_count_after="$(curl -fsS "${HAPI_BASE_URL}/Observation?subject=Patient/${prefixed_patient_id}&_summary=count" | jq -r '.total // 0')"
+obs_count_after="$(curl -fsS "${HAPI_BASE_URL}/Observation?subject=Patient/${server_patient_id}&_summary=count" | jq -r '.total // 0')"
 if ! [[ "$obs_count_after" =~ ^[0-9]+$ ]] || [ "$obs_count_after" -lt 2 ]; then
   error "Expected at least two observations after re-ingest, got ${obs_count_after}"
   exit 1
@@ -265,5 +265,67 @@ if [ "$REQUEST_STATUS" -lt 400 ]; then
   error "Expected empty bundle request to fail, got HTTP ${REQUEST_STATUS}"
   exit 1
 fi
+
+log "Ingesting DSTU2 Apple HealthKit sample (Sample C)"
+dstu2_fixture="$ROOT_DIR/app/synthea_server/test_fixtures/apple_healthkit_dstu2_c.json"
+dstu2_cohort_id="ci-apple-dstu2"
+# Sample C references Patient/19035 (Salinas, Candace) without a contained
+# Patient resource, so the import path must synthesize a stub Patient for it.
+dstu2_src_patient_id="19035"
+
+dstu2_bundle="$(jq -c '.' "$dstu2_fixture")"
+dstu2_request="$(jq -nc \
+  --argjson bundle "$dstu2_bundle" \
+  --arg cohort_id "$dstu2_cohort_id" \
+  '{bundle: $bundle, cohort_id: $cohort_id, datatype: "external", source_fhir_version: "DSTU2"}'
+)"
+
+request_json "POST" "${SYNTHEA_BASE_URL}/ingest-external-fhir" "$dstu2_request"
+
+if [ "$REQUEST_STATUS" != "200" ]; then
+  error "DSTU2 ingestion failed with HTTP ${REQUEST_STATUS}: ${REQUEST_BODY}"
+  exit 1
+fi
+
+if ! echo "$REQUEST_BODY" | jq -e --arg cohort_id "$dstu2_cohort_id" '
+  .success == true
+  and .cohort_id == $cohort_id
+  and .datatype == "external"
+  and (.patient_count | tonumber) >= 1
+  and (.patient_ids | type == "array" and length >= 1)
+  and (.unresolved_references | type == "array")
+' >/dev/null; then
+  error "DSTU2 ingestion response validation failed: ${REQUEST_BODY}"
+  exit 1
+fi
+
+log "Confirming stub Patient carries the source-id identifier for ${dstu2_src_patient_id}"
+stub_count_before="$(curl -fsS "${HAPI_BASE_URL}/Patient?identifier=urn:charm:apple-healthkit-src-id%7C${dstu2_src_patient_id}&_summary=count" | jq -r '.total // 0')"
+if ! [[ "$stub_count_before" =~ ^[0-9]+$ ]] || [ "$stub_count_before" -lt 1 ]; then
+  error "Expected a stub Patient with identifier urn:charm:apple-healthkit-src-id|${dstu2_src_patient_id}, got count ${stub_count_before}"
+  exit 1
+fi
+
+log "Confirming DSTU2 MedicationOrder converted to R4 MedicationRequest"
+medrequest_count="$(curl -fsS "${HAPI_BASE_URL}/MedicationRequest?_summary=count" | jq -r '.total // 0')"
+if ! [[ "$medrequest_count" =~ ^[0-9]+$ ]] || [ "$medrequest_count" -lt 1 ]; then
+  error "Expected at least one MedicationRequest after DSTU2 conversion, got ${medrequest_count}"
+  exit 1
+fi
+
+log "Re-ingesting identical DSTU2 bundle to confirm idempotency"
+request_json "POST" "${SYNTHEA_BASE_URL}/ingest-external-fhir" "$dstu2_request"
+if [ "$REQUEST_STATUS" != "200" ]; then
+  error "DSTU2 re-ingestion failed with HTTP ${REQUEST_STATUS}: ${REQUEST_BODY}"
+  exit 1
+fi
+
+stub_count_after="$(curl -fsS "${HAPI_BASE_URL}/Patient?identifier=urn:charm:apple-healthkit-src-id%7C${dstu2_src_patient_id}&_summary=count" | jq -r '.total // 0')"
+if [ "$stub_count_before" != "$stub_count_after" ]; then
+  error "DSTU2 idempotency check failed: stub Patient count changed from ${stub_count_before} to ${stub_count_after}"
+  exit 1
+fi
+
+log "DSTU2 import OK"
 
 log "External FHIR ingestion validation passed for cohort ${cohort_id}"

--- a/ci/external_fhir_ingestion_validation.sh
+++ b/ci/external_fhir_ingestion_validation.sh
@@ -325,6 +325,10 @@ if [ "$stub_count_before" != "$stub_count_after" ]; then
   error "DSTU2 idempotency check failed: stub Patient count changed from ${stub_count_before} to ${stub_count_after}"
   exit 1
 fi
+if ! [[ "$stub_count_after" =~ ^[0-9]+$ ]] || [ "$stub_count_after" -ne 1 ]; then
+  error "Expected exactly one stub Patient after DSTU2 re-ingest, got ${stub_count_after}"
+  exit 1
+fi
 
 log "DSTU2 import OK"
 

--- a/ci/external_fhir_ingestion_validation.sh
+++ b/ci/external_fhir_ingestion_validation.sh
@@ -299,6 +299,18 @@ if ! echo "$REQUEST_BODY" | jq -e --arg cohort_id "$dstu2_cohort_id" '
   exit 1
 fi
 
+# Sample C also has an asserter/prescriber Practitioner/23 and Practitioner/24763
+# reference with no contained Practitioner resource, so those must surface as
+# unresolved references (unlike Patient/19035, which gets a synthesized stub).
+if ! echo "$REQUEST_BODY" | jq -e '
+  (.unresolved_references | length >= 2)
+  and (.unresolved_references | any(.reference == "Practitioner/23"))
+  and (.unresolved_references | any(.reference == "Practitioner/24763"))
+' >/dev/null; then
+  error "DSTU2 ingestion did not report expected dangling Practitioner references: ${REQUEST_BODY}"
+  exit 1
+fi
+
 log "Confirming stub Patient carries the source-id identifier for ${dstu2_src_patient_id}"
 stub_count_before="$(curl -fsS "${HAPI_BASE_URL}/Patient?identifier=urn:charm:apple-healthkit-src-id%7C${dstu2_src_patient_id}&_summary=count" | jq -r '.total // 0')"
 if ! [[ "$stub_count_before" =~ ^[0-9]+$ ]] || [ "$stub_count_before" -lt 1 ]; then

--- a/docs/superpowers/plans/2026-08-20-dstu2-fhir-import.md
+++ b/docs/superpowers/plans/2026-08-20-dstu2-fhir-import.md
@@ -980,6 +980,16 @@ git commit -m "feat(ingest): route external FHIR through DSTU2 conversion + isol
 **Interfaces:**
 - Consumes: the running compose stack (`router`, `synthea_server`, `fhir-converter`, `hapi`).
 
+- [ ] **Step 0: Update the EXISTING R4 assertions the migration invalidated (do this first)**
+
+Task 7 replaced the old `ext-` prefix + PUT-by-id isolation with server-assigned IDs + identifier-based `ifNoneExist`. The existing R4 test in `ci/external_fhir_ingestion_validation.sh` still assumes the old behavior and will now fail. Update it to match the new behavior — this is expected, since the R4 external path was deliberately migrated (no backward-compat constraint):
+
+- Lines ~172-176: it asserts `patient_ids[0]` starts with `ext-`. NEW behavior: the response's `patient_ids` now carry **server-assigned ids** (e.g. `"42"`), not `ext-` prefixed ones. Drop the `ext-*` expectation; just require a non-empty id string. Rename the `prefixed_patient_id` variable to something accurate like `patient_id` (it now holds the server id).
+- The downstream queries (`Patient/${id}`, `Group/${cohort_id}` membership `Patient/${id}`, `Observation?subject=Patient/${id}`, idempotency `Patient?_id=${id}&_summary=count == 1`, obs count after re-ingest) all still hold with the server id, because `upsert_group` now receives the response-derived server ids and observations resolve to the server-assigned Patient id via the transaction. Verify each still passes; adjust only what the id-shape change requires.
+- Idempotency now works via `ifNoneExist` on the resource identifier (the R4 test patient/observations get a synthesized `urn:charm:apple-healthkit-src-id` identifier from their bundle ids when they carry no identifier of their own), so re-ingest must still yield exactly one patient. Confirm empirically.
+
+**Method:** bring the stack up (Step 2), run the script once to see the old assertions fail, fix each to the new behavior, then confirm green before adding the DSTU2 case. Do NOT weaken an assertion to pass — update it to assert the new correct behavior.
+
 - [ ] **Step 1: Relocate the sample fixtures**
 
 ```bash

--- a/docs/superpowers/plans/2026-08-20-dstu2-fhir-import.md
+++ b/docs/superpowers/plans/2026-08-20-dstu2-fhir-import.md
@@ -1,0 +1,1013 @@
+# DSTU2 → R4 External FHIR Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the external FHIR ingest path accept DSTU2 (Apple HealthKit) bundles by converting them to R4 and isolating imported resources so they cannot collide with existing data.
+
+**Architecture:** A new stateless Java sidecar (`fhir-converter`) wraps HAPI's `VersionConvertorFactory_10_40` and exposes `POST /convert`, converting a bundle entry-by-entry. The Python `synthea_server` gains a focused `external_import.py` module that detects the source version, calls the sidecar for DSTU2, synthesizes stub Patients for referenced-but-absent patient ids, and rebuilds the bundle as an idempotent `urn:uuid`/`identifier`/`ifNoneExist` transaction, reporting any unresolved references. The Synthea generation path is untouched.
+
+**Tech Stack:** Java 17 + Maven + HAPI `org.hl7.fhir.convertors` (sidecar); Python 3 + FastAPI + `requests` + `pytest` (importer); Docker Compose.
+
+## Global Constraints
+
+- HAPI server is FHIR **R4** (`fhir_version: R4`), image `hapiproject/hapi:v8.2.0-2`; do not change its config.
+- Do **not** modify the Synthea generation ingest path (`post_bundle()` and its callers).
+- Services communicate by compose service name on the default network (no custom networks). Sidecar URL inside the network: `http://fhir-converter:8080`.
+- The synthetic import identifier system is the literal string `urn:charm:apple-healthkit-src-id`.
+- CHARM tag systems already in use: `urn:charm:source`, `urn:charm:datatype`, `urn:charm:cohort`, `urn:charm:created` (do not rename).
+- `source_fhir_version` request field: allowed values `"R4"` (default) and `"DSTU2"`, case-insensitive.
+- Idempotency: re-importing the same bundle must not create duplicates (relies on `ifNoneExist` matching the per-resource identifier).
+- Dangling non-Patient references are **reported, not created** and **not dropped** — left literal in the resource.
+
+---
+
+### Task 1: `fhir-converter` sidecar — Maven project + entry-wise `/convert`
+
+**Files:**
+- Create: `app/fhir-converter/pom.xml`
+- Create: `app/fhir-converter/src/main/java/org/charm/converter/ConverterService.java`
+- Create: `app/fhir-converter/src/main/java/org/charm/converter/ConverterServer.java`
+- Test: `app/fhir-converter/src/test/java/org/charm/converter/ConverterServiceTest.java`
+
+**Interfaces:**
+- Produces: HTTP `POST /convert` accepting `{"sourceVersion":"DSTU2","bundle":{…}}`, returning an R4 `collection` Bundle JSON on 200, or an R4 `OperationOutcome` JSON on 4xx/5xx.
+- Produces (Java): `ConverterService.convertBundleDstu2ToR4(String dstu2BundleJson) -> String` (R4 bundle JSON).
+
+- [ ] **Step 1: Write `pom.xml`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.charm</groupId>
+  <artifactId>fhir-converter</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- Must match the org.hl7.fhir.core line shipped with HAPI 8.2.x.
+         Verify latest on Maven Central:
+         https://central.sonatype.com/artifact/ca.uhn.hapi.fhir/org.hl7.fhir.convertors -->
+    <fhir.core.version>6.3.11</fhir.core.version>
+  </properties>
+
+  <dependencies>
+    <!-- Pulls org.hl7.fhir.dstu2 and org.hl7.fhir.r4 transitively -->
+    <dependency>
+      <groupId>ca.uhn.hapi.fhir</groupId>
+      <artifactId>org.hl7.fhir.convertors</artifactId>
+      <version>${fhir.core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>fhir-converter</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.charm.converter.ConverterServer</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```java
+package org.charm.converter;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConverterServiceTest {
+  // Minimal DSTU2 bundle: one MedicationOrder (renamed MedicationRequest in R4)
+  private static final String DSTU2 = """
+    {"resourceType":"Bundle","type":"collection","entry":[
+      {"resource":{"resourceType":"MedicationOrder","id":"13","status":"active",
+       "dateWritten":"2023-10-20","patient":{"reference":"Patient/100"},
+       "medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm/","code":"1"}]}}}
+    ]}""";
+
+  @Test
+  void convertsMedicationOrderToMedicationRequest() {
+    String r4 = ConverterService.convertBundleDstu2ToR4(DSTU2);
+    assertTrue(r4.contains("\"resourceType\":\"Bundle\""));
+    assertTrue(r4.contains("MedicationRequest"), "MedicationOrder should become MedicationRequest");
+    assertFalse(r4.contains("MedicationOrder"), "no DSTU2 MedicationOrder should remain");
+  }
+
+  @Test
+  void badResourceIsSkippedNotFatal() {
+    String bundle = "{\"resourceType\":\"Bundle\",\"type\":\"collection\",\"entry\":[" +
+        "{\"resource\":{\"resourceType\":\"NotAResource\"}}]}";
+    // Unknown resource: entry skipped, still returns a valid empty R4 bundle
+    String r4 = ConverterService.convertBundleDstu2ToR4(bundle);
+    assertTrue(r4.contains("\"resourceType\":\"Bundle\""));
+  }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd app/fhir-converter && mvn -q test`
+Expected: FAIL — `ConverterService` does not exist / does not compile.
+
+- [ ] **Step 4: Implement `ConverterService`**
+
+```java
+package org.charm.converter;
+
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_10_40;
+import org.hl7.fhir.dstu2.model.Bundle;
+import org.hl7.fhir.dstu2.model.Resource;
+
+public final class ConverterService {
+  private ConverterService() {}
+
+  /** Convert a DSTU2 bundle JSON to an R4 collection bundle JSON, entry by entry. */
+  public static String convertBundleDstu2ToR4(String dstu2BundleJson) {
+    try {
+      org.hl7.fhir.dstu2.formats.JsonParser d2 = new org.hl7.fhir.dstu2.formats.JsonParser();
+      Resource parsed = d2.parse(dstu2BundleJson.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      if (!(parsed instanceof Bundle)) {
+        throw new IllegalArgumentException("Top-level resource is not a Bundle");
+      }
+      Bundle in = (Bundle) parsed;
+
+      org.hl7.fhir.r4.model.Bundle out = new org.hl7.fhir.r4.model.Bundle();
+      out.setType(org.hl7.fhir.r4.model.Bundle.BundleType.COLLECTION);
+
+      for (Bundle.BundleEntryComponent e : in.getEntry()) {
+        if (!e.hasResource()) continue;
+        try {
+          org.hl7.fhir.r4.model.Resource r4res =
+              (org.hl7.fhir.r4.model.Resource) VersionConvertorFactory_10_40.convertResource(e.getResource());
+          out.addEntry().setResource(r4res);
+        } catch (Exception skip) {
+          // Per-resource failure: skip this entry, keep converting the rest.
+          System.err.println("Skipping unconvertible entry: " + skip.getMessage());
+        }
+      }
+
+      org.hl7.fhir.r4.formats.JsonParser r4parser = new org.hl7.fhir.r4.formats.JsonParser();
+      return r4parser.composeString(out);
+    } catch (RuntimeException re) {
+      throw re;
+    } catch (Exception ex) {
+      throw new RuntimeException("DSTU2->R4 conversion failed: " + ex.getMessage(), ex);
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd app/fhir-converter && mvn -q test`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Implement `ConverterServer` (JDK built-in HTTP server, no web framework)**
+
+```java
+package org.charm.converter;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+public class ConverterServer {
+  public static void main(String[] args) throws Exception {
+    HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+    server.createContext("/health", ex -> respond(ex, 200, "{\"status\":\"ok\"}"));
+    server.createContext("/convert", ex -> {
+      if (!"POST".equals(ex.getRequestMethod())) { respond(ex, 405, oo("not-supported","POST only")); return; }
+      try (InputStream is = ex.getRequestBody()) {
+        String body = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        // body = {"sourceVersion":"DSTU2","bundle":{...}} ; extract the bundle object.
+        String bundleJson = JsonBody.extractBundle(body);
+        String r4 = ConverterService.convertBundleDstu2ToR4(bundleJson);
+        respond(ex, 200, r4);
+      } catch (Exception e) {
+        respond(ex, 400, oo("processing", e.getMessage() == null ? "conversion error" : e.getMessage()));
+      }
+    });
+    server.setExecutor(java.util.concurrent.Executors.newFixedThreadPool(4));
+    server.start();
+    System.out.println("fhir-converter listening on :8080");
+  }
+
+  private static void respond(com.sun.net.httpserver.HttpExchange ex, int code, String json) throws java.io.IOException {
+    byte[] b = json.getBytes(StandardCharsets.UTF_8);
+    ex.getResponseHeaders().set("Content-Type", "application/fhir+json");
+    ex.sendResponseHeaders(code, b.length);
+    ex.getResponseBody().write(b);
+    ex.close();
+  }
+
+  private static String oo(String code, String diag) {
+    return "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"error\",\"code\":\""
+        + code + "\",\"diagnostics\":" + JsonBody.quote(diag) + "}]}";
+  }
+}
+```
+
+- [ ] **Step 7: Implement the tiny `JsonBody` helper**
+
+```java
+package org.charm.converter;
+
+import org.hl7.fhir.r4.model.Bundle; // reuse a JSON reader available on classpath
+
+public final class JsonBody {
+  private JsonBody() {}
+
+  /** Extract the value of the top-level "bundle" key from the request JSON. */
+  public static String extractBundle(String requestJson) {
+    com.google.gson.JsonObject root = com.google.gson.JsonParser.parseString(requestJson).getAsJsonObject();
+    if (!root.has("bundle")) throw new IllegalArgumentException("request missing 'bundle'");
+    return root.get("bundle").toString();
+  }
+
+  public static String quote(String s) {
+    return com.google.gson.JsonParser.parseString(
+        new com.google.gson.Gson().toJson(s == null ? "" : s)).toString();
+  }
+}
+```
+
+Note: Gson is on the classpath transitively via `org.hl7.fhir.*`. If `mvn dependency:tree` shows it absent, add `com.google.code.gson:gson:2.10.1` to `pom.xml`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/fhir-converter
+git commit -m "feat(fhir-converter): DSTU2->R4 entry-wise converter service"
+```
+
+---
+
+### Task 2: Containerize the sidecar and wire it into docker-compose
+
+**Files:**
+- Create: `app/fhir-converter/Dockerfile`
+- Modify: `app/docker-compose.yml` (add `fhir-converter` service; add `CONVERTER_URL` env + `depends_on` to `synthea_server`)
+
+**Interfaces:**
+- Produces: reachable service `http://fhir-converter:8080` on the compose network; env var `CONVERTER_URL` available to `synthea_server`.
+
+- [ ] **Step 1: Write the Dockerfile (multi-stage)**
+
+```dockerfile
+# --- build ---
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /src
+COPY pom.xml .
+RUN mvn -q -e -DskipTests dependency:go-offline
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+# --- run ---
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /src/target/fhir-converter.jar /app/fhir-converter.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/fhir-converter.jar"]
+```
+
+- [ ] **Step 2: Build the image to verify it compiles and packages**
+
+Run: `cd app/fhir-converter && docker build -t charm/fhir-converter .`
+Expected: image builds successfully.
+
+- [ ] **Step 3: Add the service to `app/docker-compose.yml`**
+
+Add under `services:` (sibling of `hapi`):
+
+```yaml
+  fhir-converter:
+    build: ./fhir-converter
+    # no host port needed; internal only
+```
+
+- [ ] **Step 4: Add converter dependency to `synthea_server` service**
+
+In the `synthea_server` service block, add `fhir-converter` to `depends_on` and set the env var:
+
+```yaml
+  synthea_server:
+    depends_on:
+      hapi:
+        condition: service_started
+      fhir-converter:
+        condition: service_started
+    build: ./synthea_server
+    environment:
+      - CONVERTER_URL=http://fhir-converter:8080
+```
+
+(Merge with existing `depends_on`/`environment` keys if present — do not duplicate the keys.)
+
+- [ ] **Step 5: Verify the service starts and answers**
+
+Run:
+```bash
+cd app && docker compose up -d fhir-converter
+sleep 5
+docker compose exec -T synthea_server sh -lc 'curl -sf http://fhir-converter:8080/health'
+```
+Expected: `{"status":"ok"}`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/fhir-converter/Dockerfile app/docker-compose.yml
+git commit -m "feat(fhir-converter): dockerize and wire into compose"
+```
+
+---
+
+### Task 3: Python test harness + `detect_fhir_version`
+
+**Files:**
+- Create: `app/synthea_server/synthea-pyserver/external_import.py`
+- Create: `app/synthea_server/synthea-pyserver/tests/__init__.py` (empty)
+- Create: `app/synthea_server/synthea-pyserver/tests/test_external_import.py`
+- Modify: `app/synthea_server/pyproject.toml` (add pytest dev group + pytest config)
+
+**Interfaces:**
+- Produces: `detect_fhir_version(bundle: dict, hint: str | None = None) -> str` returning `"R4"` or `"DSTU2"`.
+
+- [ ] **Step 1: Add pytest to `pyproject.toml`**
+
+Add a dev group and pytest rootdir config:
+
+```toml
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2.0"
+
+[tool.pytest.ini_options]
+rootdir = "synthea-pyserver"
+testpaths = ["synthea-pyserver/tests"]
+```
+
+Then: `cd app/synthea_server && poetry install --with dev`
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/test_external_import.py
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import external_import as ei
+
+
+def test_explicit_hint_wins():
+    assert ei.detect_fhir_version({"resourceType": "Bundle", "entry": []}, hint="dstu2") == "DSTU2"
+    assert ei.detect_fhir_version({"resourceType": "Bundle", "entry": []}, hint="R4") == "R4"
+
+
+def test_heuristic_detects_dstu2_medicationorder():
+    bundle = {"resourceType": "Bundle", "entry": [
+        {"resource": {"resourceType": "MedicationOrder", "id": "1"}}]}
+    assert ei.detect_fhir_version(bundle) == "DSTU2"
+
+
+def test_heuristic_detects_dstu2_category_object():
+    bundle = {"resourceType": "Bundle", "entry": [
+        {"resource": {"resourceType": "Observation",
+                      "category": {"coding": [{"code": "laboratory"}]}}}]}
+    assert ei.detect_fhir_version(bundle) == "DSTU2"
+
+
+def test_heuristic_defaults_r4():
+    bundle = {"resourceType": "Bundle", "entry": [
+        {"resource": {"resourceType": "Observation", "category": [{"coding": []}]}}]}
+    assert ei.detect_fhir_version(bundle) == "R4"
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -v`
+Expected: FAIL — `external_import` has no `detect_fhir_version`.
+
+- [ ] **Step 4: Implement `detect_fhir_version`**
+
+```python
+# external_import.py
+"""External FHIR import: version detection, stub patients, isolation transaction.
+
+Kept separate from main.py so these pure functions are unit-testable without
+importing the FastAPI application.
+"""
+from __future__ import annotations
+
+# Resource types that were renamed/removed after DSTU2 (strong DSTU2 signal).
+_DSTU2_ONLY_TYPES = {"MedicationOrder", "DeviceUseRequest", "DiagnosticOrder", "BodySite"}
+
+
+def detect_fhir_version(bundle: dict, hint: str | None = None) -> str:
+    """Return "DSTU2" or "R4". Explicit hint wins; otherwise use structural heuristics."""
+    if hint:
+        h = hint.strip().upper()
+        if h in ("DSTU2", "R4"):
+            return h
+    for entry in bundle.get("entry", []):
+        res = entry.get("resource", {})
+        if res.get("resourceType") in _DSTU2_ONLY_TYPES:
+            return "DSTU2"
+        # DSTU2 Observation.category is a single object; R4 makes it an array.
+        if res.get("resourceType") == "Observation" and isinstance(res.get("category"), dict):
+            return "DSTU2"
+    return "R4"
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/synthea_server/pyproject.toml app/synthea_server/poetry.lock app/synthea_server/synthea-pyserver/external_import.py app/synthea_server/synthea-pyserver/tests
+git commit -m "feat(external-import): pytest harness + detect_fhir_version"
+```
+
+---
+
+### Task 4: `synthesize_stub_patients`
+
+**Files:**
+- Modify: `app/synthea_server/synthea-pyserver/external_import.py`
+- Modify: `app/synthea_server/synthea-pyserver/tests/test_external_import.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `synthesize_stub_patients(bundle: dict) -> dict` — returns a new bundle where every `Patient/<id>` referenced but not contained has a minimal R4 Patient added (carrying `identifier` = the source id under system `urn:charm:apple-healthkit-src-id`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_synthesizes_missing_patient():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Observation", "id": "1",
+                      "subject": {"reference": "Patient/100"}}}]}
+    out = ei.synthesize_stub_patients(bundle)
+    patients = [e["resource"] for e in out["entry"]
+                if e["resource"]["resourceType"] == "Patient"]
+    assert len(patients) == 1
+    assert patients[0]["id"] == "100"
+    assert patients[0]["identifier"][0]["system"] == "urn:charm:apple-healthkit-src-id"
+    assert patients[0]["identifier"][0]["value"] == "100"
+
+
+def test_does_not_duplicate_existing_patient():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Patient", "id": "100"}},
+        {"resource": {"resourceType": "Observation", "id": "1",
+                      "subject": {"reference": "Patient/100"}}}]}
+    out = ei.synthesize_stub_patients(bundle)
+    patients = [e["resource"] for e in out["entry"]
+                if e["resource"]["resourceType"] == "Patient"]
+    assert len(patients) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -k stub -v`
+Expected: FAIL — no `synthesize_stub_patients`.
+
+- [ ] **Step 3: Implement `synthesize_stub_patients`**
+
+```python
+import copy
+
+SRC_ID_SYSTEM = "urn:charm:apple-healthkit-src-id"
+
+
+def _iter_references(obj):
+    """Yield every reference string found anywhere in a nested structure."""
+    if isinstance(obj, dict):
+        ref = obj.get("reference")
+        if isinstance(ref, str):
+            yield ref
+        for v in obj.values():
+            yield from _iter_references(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_references(item)
+
+
+def synthesize_stub_patients(bundle: dict) -> dict:
+    """Add a minimal R4 Patient for each Patient/<id> referenced but not contained."""
+    bundle = copy.deepcopy(bundle)
+    entries = bundle.setdefault("entry", [])
+
+    present = {e["resource"]["id"] for e in entries
+               if e.get("resource", {}).get("resourceType") == "Patient" and e["resource"].get("id")}
+
+    referenced = set()
+    for e in entries:
+        for ref in _iter_references(e.get("resource", {})):
+            if ref.startswith("Patient/"):
+                referenced.add(ref[len("Patient/"):])
+
+    for pid in sorted(referenced - present):
+        entries.append({"resource": {
+            "resourceType": "Patient",
+            "id": pid,
+            "identifier": [{"system": SRC_ID_SYSTEM, "value": pid}],
+        }})
+    return bundle
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -k stub -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/synthea_server/synthea-pyserver/external_import.py app/synthea_server/synthea-pyserver/tests/test_external_import.py
+git commit -m "feat(external-import): synthesize stub patients for absent references"
+```
+
+---
+
+### Task 5: `build_isolation_transaction`
+
+**Files:**
+- Modify: `app/synthea_server/synthea-pyserver/external_import.py`
+- Modify: `app/synthea_server/synthea-pyserver/tests/test_external_import.py`
+
+**Interfaces:**
+- Consumes: `_iter_references`, `SRC_ID_SYSTEM` (Task 4).
+- Produces: `build_isolation_transaction(bundle: dict) -> tuple[dict, list[dict]]` — returns `(transaction_bundle, unresolved_references)` where `unresolved_references` is a list of `{"source": "<Type>/<srcId>", "reference": "<danglingRef>"}`.
+
+Behavior:
+- Every entry gets `fullUrl = "urn:uuid:<uuid4>"`.
+- References whose `<Type>/<id>` matches an in-bundle resource are rewritten to that resource's `urn:uuid:`.
+- References whose target is not in-bundle are left literal and recorded in `unresolved_references`.
+- Each entry's `request` is `POST <Type>` with `ifNoneExist` on the resource's identifier: prefer an existing `identifier` (first entry, `system|value`); else synthesize one from the resource `id` under `SRC_ID_SYSTEM` and match on it. Resources with neither an identifier nor an `id` use a plain `POST` with no `ifNoneExist`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_isolation_rewrites_in_bundle_refs_and_reports_dangling():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Patient", "id": "100",
+                      "identifier": [{"system": "urn:charm:apple-healthkit-src-id", "value": "100"}]}},
+        {"resource": {"resourceType": "Observation", "id": "1",
+                      "subject": {"reference": "Patient/100"},
+                      "encounter": {"reference": "Encounter/355"}}},
+    ]}
+    txn, unresolved = ei.build_isolation_transaction(bundle)
+
+    assert txn["type"] == "transaction"
+    # every entry has a urn:uuid fullUrl and a POST request
+    for e in txn["entry"]:
+        assert e["fullUrl"].startswith("urn:uuid:")
+        assert e["request"]["method"] == "POST"
+        assert "ifNoneExist" in e["request"]
+
+    # the in-bundle Patient ref was rewritten to the Patient entry's urn:uuid
+    patient_uuid = next(e["fullUrl"] for e in txn["entry"]
+                        if e["resource"]["resourceType"] == "Patient")
+    obs = next(e["resource"] for e in txn["entry"]
+               if e["resource"]["resourceType"] == "Observation")
+    assert obs["subject"]["reference"] == patient_uuid
+
+    # the dangling Encounter ref is untouched and reported
+    assert obs["encounter"]["reference"] == "Encounter/355"
+    assert {"source": "Observation/1", "reference": "Encounter/355"} in unresolved
+
+
+def test_isolation_synthesizes_identifier_when_absent():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Condition", "id": "7"}}]}
+    txn, _ = ei.build_isolation_transaction(bundle)
+    req = txn["entry"][0]["request"]
+    assert req["method"] == "POST"
+    assert req["url"] == "Condition"
+    assert "identifier=urn:charm:apple-healthkit-src-id%7C7" in req["ifNoneExist"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -k isolation -v`
+Expected: FAIL — no `build_isolation_transaction`.
+
+- [ ] **Step 3: Implement `build_isolation_transaction`**
+
+```python
+import uuid
+from urllib.parse import quote as _urlquote
+
+
+def _primary_identifier(resource: dict) -> tuple[str, str] | None:
+    """Return (system, value) of the resource's first identifier, or None."""
+    ids = resource.get("identifier")
+    if isinstance(ids, list) and ids:
+        first = ids[0]
+        if isinstance(first, dict) and first.get("system") and first.get("value") is not None:
+            return first["system"], str(first["value"])
+    return None
+
+
+def build_isolation_transaction(bundle: dict) -> tuple[dict, list[dict]]:
+    bundle = copy.deepcopy(bundle)
+    entries = bundle.get("entry", [])
+
+    # 1. Assign a urn:uuid to every entry and index (Type/id) -> urn:uuid.
+    ref_index: dict[str, str] = {}
+    for e in entries:
+        res = e.get("resource", {})
+        e["fullUrl"] = f"urn:uuid:{uuid.uuid4()}"
+        rtype, rid = res.get("resourceType"), res.get("id")
+        if rtype and rid:
+            ref_index[f"{rtype}/{rid}"] = e["fullUrl"]
+
+    # 2. Rewrite in-bundle refs to urn:uuid; collect dangling ones.
+    unresolved: list[dict] = []
+
+    def rewrite(obj, source_label):
+        if isinstance(obj, dict):
+            ref = obj.get("reference")
+            if isinstance(ref, str) and "/" in ref and not ref.startswith("urn:"):
+                if ref in ref_index:
+                    obj["reference"] = ref_index[ref]
+                else:
+                    unresolved.append({"source": source_label, "reference": ref})
+            for v in obj.values():
+                rewrite(v, source_label)
+        elif isinstance(obj, list):
+            for item in obj:
+                rewrite(item, source_label)
+
+    for e in entries:
+        res = e.get("resource", {})
+        source_label = f"{res.get('resourceType')}/{res.get('id')}" if res.get("id") else res.get("resourceType", "?")
+        rewrite(res, source_label)
+
+    # 3. Build POST + ifNoneExist request per entry (idempotent conditional-create).
+    for e in entries:
+        res = e.get("resource", {})
+        rtype = res.get("resourceType")
+        ident = _primary_identifier(res)
+        if ident is None and res.get("id"):
+            ident = (SRC_ID_SYSTEM, str(res["id"]))
+            res.setdefault("identifier", []).append({"system": ident[0], "value": ident[1]})
+        # Server assigns the id; drop the source id so it is never asserted.
+        res.pop("id", None)
+        req = {"method": "POST", "url": rtype}
+        if ident is not None:
+            token = f"{ident[0]}|{ident[1]}"
+            req["ifNoneExist"] = f"identifier={_urlquote(token, safe='')}"
+        e["request"] = req
+
+    bundle["type"] = "transaction"
+    return bundle, unresolved
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -k isolation -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/synthea_server/synthea-pyserver/external_import.py app/synthea_server/synthea-pyserver/tests/test_external_import.py
+git commit -m "feat(external-import): urn:uuid/ifNoneExist isolation transaction with dangling-ref report"
+```
+
+---
+
+### Task 6: Converter client `convert_bundle`
+
+**Files:**
+- Modify: `app/synthea_server/synthea-pyserver/external_import.py`
+- Modify: `app/synthea_server/synthea-pyserver/tests/test_external_import.py`
+
+**Interfaces:**
+- Produces: `convert_bundle(bundle: dict, source_version: str, converter_url: str, session=None) -> dict` — returns an R4 bundle. If `source_version == "R4"`, returns the bundle unchanged (no network call). If `"DSTU2"`, POSTs `{"sourceVersion":"DSTU2","bundle":bundle}` to `<converter_url>/convert` and returns the parsed R4 JSON. Raises `ConversionError` on non-2xx.
+
+- [ ] **Step 1: Write the failing test (HTTP mocked via a fake session)**
+
+```python
+class _FakeResp:
+    def __init__(self, status, payload): self.status_code = status; self._p = payload
+    def json(self): return self._p
+    @property
+    def text(self): import json; return json.dumps(self._p)
+
+class _FakeSession:
+    def __init__(self, resp): self.resp = resp; self.calls = []
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.calls.append((url, json)); return self.resp
+
+
+def test_r4_is_passthrough_no_network():
+    sess = _FakeSession(_FakeResp(500, {}))  # would error if called
+    b = {"resourceType": "Bundle", "entry": []}
+    assert ei.convert_bundle(b, "R4", "http://c:8080", session=sess) is b
+    assert sess.calls == []
+
+
+def test_dstu2_calls_converter():
+    r4 = {"resourceType": "Bundle", "type": "collection", "entry": []}
+    sess = _FakeSession(_FakeResp(200, r4))
+    b = {"resourceType": "Bundle", "entry": [{"resource": {"resourceType": "MedicationOrder"}}]}
+    out = ei.convert_bundle(b, "DSTU2", "http://c:8080", session=sess)
+    assert out == r4
+    assert sess.calls[0][0] == "http://c:8080/convert"
+    assert sess.calls[0][1]["sourceVersion"] == "DSTU2"
+
+
+def test_converter_error_raises():
+    sess = _FakeSession(_FakeResp(400, {"resourceType": "OperationOutcome"}))
+    import pytest
+    with pytest.raises(ei.ConversionError):
+        ei.convert_bundle({"resourceType": "Bundle"}, "DSTU2", "http://c:8080", session=sess)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -k convert -v`
+Expected: FAIL — no `convert_bundle` / `ConversionError`.
+
+- [ ] **Step 3: Implement `convert_bundle`**
+
+```python
+import requests
+
+
+class ConversionError(Exception):
+    pass
+
+
+def convert_bundle(bundle: dict, source_version: str, converter_url: str, session=None) -> dict:
+    if source_version.upper() == "R4":
+        return bundle
+    sess = session or requests.Session()
+    url = converter_url.rstrip("/") + "/convert"
+    resp = sess.post(url, json={"sourceVersion": "DSTU2", "bundle": bundle},
+                     headers={"Content-Type": "application/json"}, timeout=120)
+    if resp.status_code not in (200, 201):
+        raise ConversionError(f"converter returned {resp.status_code}: {resp.text[:500]}")
+    return resp.json()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -k convert -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/synthea_server/synthea-pyserver/external_import.py app/synthea_server/synthea-pyserver/tests/test_external_import.py
+git commit -m "feat(external-import): converter sidecar client with R4 passthrough"
+```
+
+---
+
+### Task 7: Wire the pipeline into the endpoint + contract changes
+
+**Files:**
+- Modify: `app/synthea_server/synthea-pyserver/main.py` (`ExternalFHIRRequest`, `ingest_external_fhir`)
+- Modify: `app/router/router/routers/ingestion.py` (`ExternalFHIRIngestRequest`, forwarding)
+- Modify: `app/synthea_server/synthea-pyserver/tests/test_external_import.py` (orchestration test)
+
+**Interfaces:**
+- Consumes: `detect_fhir_version`, `convert_bundle`, `synthesize_stub_patients`, `build_isolation_transaction` (Tasks 3–6).
+- Produces: `assemble_external_import(bundle, source_fhir_version, converter_url, session=None) -> tuple[dict, list[dict]]` in `external_import.py` — the full detect→convert→stub→isolation pipeline, returning `(transaction_bundle, unresolved_references)`. The endpoint calls this, then tags + POSTs to HAPI.
+
+- [ ] **Step 1: Write the failing orchestration test**
+
+```python
+def test_assemble_external_import_end_to_end_r4():
+    bundle = {"resourceType": "Bundle", "type": "collection", "entry": [
+        {"resource": {"resourceType": "Observation", "id": "1",
+                      "subject": {"reference": "Patient/100"}}}]}
+    txn, unresolved = ei.assemble_external_import(bundle, "R4", "http://c:8080")
+    assert txn["type"] == "transaction"
+    types = {e["resource"]["resourceType"] for e in txn["entry"]}
+    assert "Patient" in types            # stub synthesized
+    assert unresolved == []              # Patient/100 now resolves in-bundle
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -k assemble -v`
+Expected: FAIL — no `assemble_external_import`.
+
+- [ ] **Step 3: Implement `assemble_external_import`**
+
+```python
+def assemble_external_import(bundle: dict, source_fhir_version: str | None,
+                             converter_url: str, session=None) -> tuple[dict, list[dict]]:
+    version = detect_fhir_version(bundle, hint=source_fhir_version)
+    r4 = convert_bundle(bundle, version, converter_url, session=session)
+    stubbed = synthesize_stub_patients(r4)
+    return build_isolation_transaction(stubbed)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app/synthea_server && poetry run pytest synthea-pyserver/tests/test_external_import.py -k assemble -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update `ExternalFHIRRequest` and the endpoint in `main.py`**
+
+Add the field to `ExternalFHIRRequest` (after `datatype`):
+
+```python
+    source_fhir_version: str = Field("R4", description="Source FHIR version: 'R4' (default) or 'DSTU2'")
+```
+
+At the top of `main.py`, add the import and converter URL:
+
+```python
+import external_import
+CONVERTER_URL = os.environ.get("CONVERTER_URL", "http://fhir-converter:8080")
+```
+
+Replace the body of `ingest_external_fhir` between the bundle-validation block and the "Apply tags" block. Old lines (build the transaction the old way):
+
+```python
+        # Prefix patient IDs to prevent conflicts
+        prefixed_bundle = prefix_patient_ids(request.bundle, prefix="ext-")
+
+        # Convert to transaction bundle for atomic updates
+        transaction_bundle = convert_to_transaction_bundle(prefixed_bundle)
+```
+
+New:
+
+```python
+        # Detect version, convert if DSTU2, synthesize stub patients, isolate ids.
+        transaction_bundle, unresolved_refs = external_import.assemble_external_import(
+            request.bundle, request.source_fhir_version, CONVERTER_URL,
+        )
+        if unresolved_refs:
+            logger.warning(f"{len(unresolved_refs)} unresolved reference(s) in import")
+```
+
+Then, where the endpoint builds its JSON response, include the report. Find the success `return`/`JSONResponse` and add `"unresolved_references": unresolved_refs` to its content dict. (If the handler returns `{"success": True, ...}`, add the key there.)
+
+Note: keep `prefix_patient_ids` and `convert_to_transaction_bundle` defined — they are still referenced by other flows (grep confirms line ~3477). Only the external endpoint stops calling them.
+
+- [ ] **Step 6: Add `source_fhir_version` to the router and forward it**
+
+In `app/router/router/routers/ingestion.py`, add to `ExternalFHIRIngestRequest`:
+
+```python
+    source_fhir_version: str = Field("R4", description="Source FHIR version: 'R4' or 'DSTU2'")
+```
+
+Ensure the forwarded payload to `{synthea_server_url}/ingest-external-fhir` includes `source_fhir_version` (add it to the dict/`model_dump()` used in the `httpx` POST body).
+
+- [ ] **Step 7: Run the module tests + a syntax check on the endpoints**
+
+Run:
+```bash
+cd app/synthea_server && poetry run pytest synthea-pyserver/tests -v
+python -c "import ast; ast.parse(open('synthea-pyserver/main.py').read())"
+python -c "import ast; ast.parse(open('../router/router/routers/ingestion.py').read())"
+```
+Expected: all pytest pass; both `ast.parse` produce no output (valid syntax).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/synthea_server/synthea-pyserver/external_import.py app/synthea_server/synthea-pyserver/main.py app/router/router/routers/ingestion.py app/synthea_server/synthea-pyserver/tests/test_external_import.py
+git commit -m "feat(ingest): route external FHIR through DSTU2 conversion + isolation"
+```
+
+---
+
+### Task 8: End-to-end validation with the Apple samples + fixture relocation
+
+**Files:**
+- Create: `app/synthea_server/test_fixtures/apple_healthkit_dstu2_a.json` (moved from `app/hapi/Sample A.json`)
+- Create: `app/synthea_server/test_fixtures/apple_healthkit_dstu2_b.json` (moved from `app/hapi/Sample B.json`)
+- Create: `app/synthea_server/test_fixtures/apple_healthkit_dstu2_c.json` (moved from `app/hapi/Sample C.json`)
+- Modify: `ci/external_fhir_ingestion_validation.sh` (add a DSTU2 case)
+
+**Interfaces:**
+- Consumes: the running compose stack (`router`, `synthea_server`, `fhir-converter`, `hapi`).
+
+- [ ] **Step 1: Relocate the sample fixtures**
+
+```bash
+cd /Users/oneilsh/Documents/projects/tislab/CHARM/CHARMTwinsights
+mkdir -p app/synthea_server/test_fixtures
+git mv "app/hapi/Sample A.json" app/synthea_server/test_fixtures/apple_healthkit_dstu2_a.json
+git mv "app/hapi/Sample B.json" app/synthea_server/test_fixtures/apple_healthkit_dstu2_b.json
+git mv "app/hapi/Sample C.json" app/synthea_server/test_fixtures/apple_healthkit_dstu2_c.json
+```
+
+- [ ] **Step 2: Bring up the stack**
+
+Run: `cd app && docker compose up -d --build hapi hapi_db fhir-converter synthea_server router`
+Expected: all containers healthy; `docker compose exec -T synthea_server sh -lc 'curl -sf http://fhir-converter:8080/health'` returns ok.
+
+- [ ] **Step 3: Add a DSTU2 case to the CI script**
+
+Append to `ci/external_fhir_ingestion_validation.sh` a block that POSTs a DSTU2 sample through the router with `source_fhir_version=DSTU2`, then asserts against HAPI. Concretely:
+
+```bash
+echo "== DSTU2 Apple import =="
+BUNDLE=$(cat app/synthea_server/test_fixtures/apple_healthkit_dstu2_c.json)
+REQ=$(jq -n --argjson b "$BUNDLE" \
+  '{bundle:$b, cohort_id:"apple-test", datatype:"external", source_fhir_version:"DSTU2"}')
+
+RESP=$(curl -sf -X POST "$ROUTER_BASE_URL/ingest/fhir" \
+  -H "Content-Type: application/json" -d "$REQ")
+echo "$RESP" | jq .
+
+# 1. import reported unresolved references (Encounter/... present in sample C)
+echo "$RESP" | jq -e '.unresolved_references | length >= 0' >/dev/null
+
+# 2. a stub Patient now exists with the source-id identifier
+curl -sf "$HAPI_BASE_URL/Patient?identifier=urn:charm:apple-healthkit-src-id|1" \
+  | jq -e '.total >= 1' >/dev/null
+
+# 3. no DSTU2 MedicationOrder leaked; it converted to MedicationRequest
+curl -sf "$HAPI_BASE_URL/MedicationRequest?_count=1" | jq -e '.resourceType=="Bundle"' >/dev/null
+
+# 4. idempotency: re-POST identical request, Patient count unchanged
+BEFORE=$(curl -sf "$HAPI_BASE_URL/Patient?identifier=urn:charm:apple-healthkit-src-id|1" | jq '.total')
+curl -sf -X POST "$ROUTER_BASE_URL/ingest/fhir" -H "Content-Type: application/json" -d "$REQ" >/dev/null
+AFTER=$(curl -sf "$HAPI_BASE_URL/Patient?identifier=urn:charm:apple-healthkit-src-id|1" | jq '.total')
+[ "$BEFORE" = "$AFTER" ] || { echo "IDEMPOTENCY FAIL: $BEFORE -> $AFTER"; exit 1; }
+echo "DSTU2 import OK"
+```
+
+(Match the existing script's variable names for `ROUTER_BASE_URL` / `HAPI_BASE_URL`; reuse whatever it already defines.)
+
+- [ ] **Step 4: Run the CI validation script**
+
+Run: `cd /Users/oneilsh/Documents/projects/tislab/CHARM/CHARMTwinsights && bash ci/external_fhir_ingestion_validation.sh`
+Expected: script exits 0, prints `DSTU2 import OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/synthea_server/test_fixtures ci/external_fhir_ingestion_validation.sh
+git commit -m "test(ingest): e2e DSTU2 Apple import validation + relocate fixtures"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Layer 1 conversion → Tasks 1–2, 6. ✓
+- Layer 2 ID isolation (all resources, server-assigned) → Task 5. ✓
+- Layer 3 dangling-ref report → Task 5 (`unresolved`), surfaced in Task 7 response, asserted Task 8. ✓
+- Layer 4 stub Patient + cohort membership → Task 4; cohort `upsert_group` keeps working because stub Patients are present before the existing patient-id extraction (Task 7 leaves that block intact). ✓
+- Idempotent re-import (`ifNoneExist`) → Task 5, asserted Task 8 step 3. ✓
+- API changes (`source_fhir_version`, `unresolved_references`) → Task 7. ✓
+- Migrate mobile path (shared logic) → Task 7 routes ALL external bundles through `assemble_external_import`; R4 passthrough skips only the convert call. ✓
+- Sidecar generality across resource types → Task 1 entry-wise loop. ✓
+- Fixture relocation → Task 8. ✓
+
+**Compatibility assumption (from spec §5):** the mobile-path migration is behavior-changing for any client that reads back by hardcoded server id. Not code — flagged here so the executor surfaces it in the PR description for the FHIR-HOSE owner to confirm.
+
+**Placeholder scan:** no TBD/TODO; every code step has concrete content. The one soft spot — the exact `org.hl7.fhir.convertors` version — is given a concrete value (`6.3.11`) plus a verification URL, not left blank.
+
+**Type consistency:** `detect_fhir_version(bundle, hint)`, `synthesize_stub_patients(bundle)`, `build_isolation_transaction(bundle) -> (dict, list)`, `convert_bundle(bundle, source_version, converter_url, session)`, `assemble_external_import(bundle, source_fhir_version, converter_url, session)` — names/signatures consistent across Tasks 3–7. `SRC_ID_SYSTEM` / `urn:charm:apple-healthkit-src-id` identical in code, tests, and CI assertions.

--- a/docs/superpowers/plans/2026-08-20-dstu2-fhir-import.md
+++ b/docs/superpowers/plans/2026-08-20-dstu2-fhir-import.md
@@ -890,6 +890,56 @@ Then, where the endpoint builds its JSON response, include the report. Find the 
 
 Note: keep `prefix_patient_ids` and `convert_to_transaction_bundle` defined — they are still referenced by other flows (grep confirms line ~3477). Only the external endpoint stops calling them.
 
+- [ ] **Step 5b: Derive cohort patient IDs from the transaction RESPONSE, not the request**
+
+**Why (plan defect fix):** the old endpoint built `patient_ids` from `resource.get("id")` on Patient resources in the bundle *before* POSTing, then fed them to `upsert_group`. But `build_isolation_transaction` now **drops** every resource `id` (HAPI assigns them via conditional-create), so reading ids from the request bundle yields nothing and cohorts never populate. The server-assigned ids only exist in the transaction response.
+
+Replace the old pre-POST patient-id extraction block:
+
+```python
+        # Extract patient IDs before posting (for cohort management)
+        patient_ids = set()
+        for entry in transaction_bundle.get("entry", []):
+            resource = entry.get("resource", {})
+            if resource.get("resourceType") == "Patient":
+                patient_id = resource.get("id")
+                if patient_id:
+                    patient_ids.add(patient_id)
+```
+
+with: (a) BEFORE the POST, record which request-entry indices are Patients —
+
+```python
+        # The transaction drops resource ids (server assigns them via
+        # conditional-create), so cohort patient ids must come from the
+        # response, not the request. Record which entries are Patients by index.
+        patient_entry_indices = [
+            i for i, entry in enumerate(transaction_bundle.get("entry", []))
+            if entry.get("resource", {}).get("resourceType") == "Patient"
+        ]
+```
+
+and (b) AFTER the success check (`r.status_code` in 200/201), parse the response bundle for the server-assigned ids —
+
+```python
+        # Pull server-assigned Patient ids from the transaction response.
+        # Each response entry lines up with its request entry by index; a
+        # created/matched resource reports response.location = "Patient/<id>/_history/..".
+        patient_ids = set()
+        try:
+            resp_entries = r.json().get("entry", [])
+            for i in patient_entry_indices:
+                if i < len(resp_entries):
+                    location = resp_entries[i].get("response", {}).get("location", "")
+                    parts = location.split("/")
+                    if len(parts) >= 2 and parts[0] == "Patient" and parts[1]:
+                        patient_ids.add(parts[1])
+        except (ValueError, KeyError, AttributeError) as e:
+            logger.warning(f"Could not parse patient ids from transaction response: {e}")
+```
+
+This runs where the current `patient_ids`/`upsert_group` block sits (the existing `if patient_ids: upsert_group(...)` and the response's `patient_count`/`patient_ids` keys stay as-is, now fed by the response-derived set). It is correct for idempotent re-import too: an `ifNoneExist` match returns the existing resource's location, so the same server id comes back.
+
 - [ ] **Step 6: Add `source_fhir_version` to the router and forward it**
 
 In `app/router/router/routers/ingestion.py`, add to `ExternalFHIRIngestRequest`:

--- a/docs/superpowers/specs/2026-08-20-dstu2-fhir-import-design.md
+++ b/docs/superpowers/specs/2026-08-20-dstu2-fhir-import-design.md
@@ -1,0 +1,163 @@
+# DSTU2 → R4 External FHIR Import — Design
+
+**Date:** 2026-08-20
+**Branch:** `dstu2-import`
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+The repo can ingest external FHIR bundles via `POST /ingest/fhir` (router) →
+`POST /ingest-external-fhir` (synthea_server) → HAPI. But:
+
+1. **Version mismatch.** We have Apple HealthKit clinical sample bundles in FHIR
+   **DSTU2** (confirmed: `MedicationOrder` resource, single-object
+   `Observation.category`, `dateWritten`). HAPI is configured `fhir_version: R4`
+   ([app/hapi/hapi.application.yaml:70](../../../app/hapi/hapi.application.yaml))
+   and rejects DSTU2.
+
+2. **Pre-existing import-isolation gaps that DSTU2/Apple bundles expose.** The
+   current external path (`ingest_external_fhir` → `prefix_patient_ids` →
+   `convert_to_transaction_bundle`) only namespaces **Patient** IDs (`ext-`
+   prefix) and emits `PUT ResourceType/<rawId>` for everything else. Against
+   HAPI's default `SEQUENTIAL_NUMERIC` server IDs + permissive client-ID
+   strategy, a bare Apple id like `Observation/1` **overwrites** a Synthea
+   resource already at server id `1`. Apple bundles also (a) contain **no
+   Patient resource** despite referencing `Patient/1`, and (b) reference
+   `Practitioner/20`, `Encounter/355`, etc. that they don't contain.
+
+These are genuinely separate layers; the version conversion is the easy one.
+
+## Goals
+
+Make external DSTU2 (initially Apple HealthKit) bundles ingest reliably as an
+**ongoing production capability**, general across resource types, without
+corrupting existing (Synthea or other-import) data.
+
+## Non-goals
+
+- Stubbing external Practitioner/Encounter/etc. resources (they are reported,
+  not created — see Layer 3).
+- Enabling HAPI referential integrity globally (would break Synthea's
+  forward-reference ingestion, which relies on it being off).
+- Terminology / value-set translation beyond what the HAPI converter performs.
+- Touching the **Synthea generation** ingest path (`post_bundle()`), which
+  already POSTs `urn:uuid` transaction bundles with rich business identifiers
+  and needs none of this treatment.
+
+## Decisions (locked during brainstorming)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Conversion engine | **Java sidecar** wrapping HAPI `VersionConvertorFactory_10_40` |
+| 2 | Scope | **Full isolation** — convert + ID isolation + dangling-ref handling + stub Patient/cohort |
+| 3 | ID isolation | **Identifier + server-assigned IDs** — source id → `identifier`, `urn:uuid` transaction refs, `ifNoneExist` conditional-create (idempotent re-import) |
+| 4 | Dangling non-Patient refs | **Report + allow** — leave literal, return an `unresolved_references` report |
+| 5 | Missing Patient | **Synthesize stub Patient**, wire into cohort membership |
+| 6 | Mobile (FHIR-HOSE) path | **Migrate too** — R4 external bundles use the same isolation logic (skip convert step) — see Compatibility Assumption |
+
+## Architecture & data flow
+
+```
+router  POST /ingest/fhir   (+ optional source_fhir_version)
+  └─> synthea_server  POST /ingest-external-fhir
+        1. detect/receive FHIR version (explicit hint wins; heuristic fallback)
+        2. if DSTU2 → POST to fhir-converter sidecar → R4 bundle
+        3. synthesize stub Patient(s) for referenced-but-absent patient ids
+        4. build isolation transaction:
+             - assign urn:uuid fullUrls
+             - prefer resource's existing identifier; else synthesize
+               identifier {system: urn:charm:apple-healthkit-src-id, value: <srcId>}
+             - rewrite in-bundle references → urn:uuid
+             - request: POST <Type>, ifNoneExist=<identifier query>
+             - collect unresolved external references
+        5. apply CHARM tags (source/datatype/cohort/created)
+        6. POST transaction to HAPI
+        7. upsert cohort Group from patient ids (now includes stub Patients)
+  └─> response: { success, patient_ids, cohort, unresolved_references[] }
+
+NEW service:  fhir-converter  (Java, containerized alongside hapi)
+        POST /convert  { sourceVersion:"DSTU2", bundle:{…} } → R4 bundle
+```
+
+### Why the `urn:uuid` + `ifNoneExist` idiom
+
+It does three jobs at once: (1) intra-bundle references resolve atomically
+without knowing server IDs in advance, (2) collisions with Synthea become
+impossible because we never assert a server ID, (3) re-importing the same
+export is a no-op — HAPI matches the `identifier` and skips the create. This
+replaces the fragile `PUT ResourceType/<rawId>` upsert.
+
+## Components
+
+### 1. `fhir-converter` sidecar (new Java service)
+
+- Minimal HTTP service (lightweight embedded server) depending on
+  `org.hl7.fhir.convertors` / `hapi-fhir-converter`.
+- Single endpoint `POST /convert`:
+  - Input: `{ sourceVersion: "DSTU2", bundle: {…} }`.
+  - Parse with the DSTU2 parser → `VersionConvertorFactory_10_40.convertResource`
+    → serialize R4 → return.
+  - Errors (parse failure, unconvertible resource) → 4xx with an
+    `OperationOutcome`.
+- Stateless, no DB. Handles all resource types generically.
+- Added to `docker-compose.yml` on the internal network; reachable at
+  `http://fhir-converter:8080/convert`. JRE base image.
+
+### 2. Importer rework in `synthea_server`
+
+Replace `prefix_patient_ids` + `convert_to_transaction_bundle` **for the
+external path** with focused, independently testable units:
+
+- `detect_fhir_version(bundle, hint) -> "R4" | "DSTU2"` — explicit
+  `source_fhir_version` wins; heuristic fallback (e.g. presence of
+  `MedicationOrder`, single-object `Observation.category`).
+- `synthesize_stub_patients(bundle) -> bundle` — scan all `Patient/<x>`
+  references; for any `<x>` with no Patient resource, add a minimal R4 Patient
+  carrying the source id as an identifier.
+- `build_isolation_transaction(bundle) -> (transaction, unresolved_refs)` — the
+  `urn:uuid` / identifier / `ifNoneExist` builder; identifier preference logic
+  (existing identifier first, synthesize only when absent); collects references
+  whose target is neither in-bundle nor a synthesized stub.
+- Cohort membership derives patient ids from the (now-present) Patients.
+
+### 3. API / contract changes
+
+- Router `ExternalFHIRIngestRequest` + synthea `ExternalFHIRRequest`: add
+  optional `source_fhir_version` (default `"R4"`).
+- Ingest response gains `unresolved_references: [{ source, reference }]`.
+
+## Compatibility assumption (must verify before release)
+
+The FHIR-HOSE mobile app is known only from a docstring
+([main.py:2960](../../../app/synthea_server/synthea-pyserver/main.py)); no client
+code or contract exists in this repo. Migrating its R4 bundles to the new
+isolation logic is safe **iff** the client interacts via cohort/tag queries
+rather than hardcoded server resource IDs, and does not depend on
+`PUT`-by-raw-id merge semantics. **Action:** confirm with the FHIR-HOSE client
+owner before shipping. Behavior preserved regardless: data still lands, carries
+the same CHARM tags, and is queryable by cohort/tag.
+
+## Testing
+
+- **Sidecar unit:** convert each of the 3 Apple samples DSTU2→R4; assert
+  `MedicationOrder`→`MedicationRequest`, `Observation.category` becomes an
+  array, `dateWritten`→`authoredOn`.
+- **Importer:** golden test that a sample ingests; stub Patient created;
+  re-import is idempotent (no duplicates); unresolved refs (`Practitioner/20`,
+  `Encounter/355`) appear in the report; no collision with a pre-seeded Synthea
+  resource sharing a bare id.
+- Extend `ci/external_fhir_ingestion_validation.sh` with a DSTU2 case.
+
+## Open risks
+
+- HAPI converter has known per-resource gaps (e.g. `Procedure.status` drop,
+  some Bundle-level quirks). Acceptable for import; surfaced via tests on real
+  samples.
+- FHIR-HOSE compatibility assumption above.
+
+## Sample data
+
+`app/hapi/Sample A.json`, `Sample B.json`, `Sample C.json` — DSTU2 `collection`
+bundles, no Patient resource, external Practitioner/Encounter references, bare
+sequential resource ids. (Relocate to a fixtures directory during
+implementation.)


### PR DESCRIPTION
## What & why

Adds the ability to ingest **DSTU2** external FHIR bundles (e.g. Apple HealthKit clinical exports) into the R4 pipeline. Previously the external-ingest path only handled R4 and only namespaced Patient IDs, so DSTU2 Apple bundles were rejected outright and, even once converted, their bare sequential IDs (`Observation/1`, …) would have collided with Synthea data.

## How it works

External ingest now runs: **detect version → convert (if DSTU2) → synthesize stub Patients → isolate → post → derive cohort membership from the response**.

- **`app/fhir-converter/`** — new stateless Java sidecar wrapping HAPI's `VersionConvertorFactory_10_40`. Converts a bundle **entry-by-entry** (skips + logs a single unconvertible resource rather than failing the whole bundle), exposing `POST /convert`. Dockerized and wired into `docker-compose` on the internal network (`CONVERTER_URL`).
- **`app/synthea_server/synthea-pyserver/external_import.py`** — new focused module:
  - `detect_fhir_version` (explicit `source_fhir_version` hint wins, else structural heuristics)
  - `synthesize_stub_patients` (creates a minimal R4 Patient for any `Patient/<id>` referenced but not contained — Apple clinical bundles omit the Patient)
  - `build_isolation_transaction` — rebuilds the bundle as a `transaction` using `urn:uuid` fullUrls + `ifNoneExist` conditional-create, moving each source id into a `urn:charm:apple-healthkit-src-id` identifier and letting HAPI assign server ids. This makes imports **idempotent** and **collision-proof** against Synthea data. Dangling external references (e.g. `Practitioner/20`, `Encounter/355`) are left literal and **reported**, not created.
  - `convert_bundle` — sidecar client with R4 passthrough (no network call for R4).
- **Endpoint + router** — `/ingest-external-fhir` calls the above, adds `source_fhir_version` to both request models (router forwards it), returns `unresolved_references`, and derives cohort patient IDs from the **transaction response** (since IDs are now server-assigned). The Synthea generation path is untouched.

## Migration note

The R4 external-ingest path was intentionally migrated to the same isolation logic (server-assigned IDs + identifier dedup, replacing the old `ext-` prefix + PUT-by-id). This was a deliberate design choice — the FHIR-HOSE mobile client that consumed the old behavior is not yet written, so there is no backward-compatibility constraint. Stale `ext-` references in docs/CI/UI were updated accordingly.

## Testing

- Python unit tests: **12/12** (`poetry run pytest`, in `synthea-pyserver/tests`).
- Java converter tests: **6/6** (`mvn test`) — incl. mixed-bundle skip-vs-abort and a real HTTP integration test on an ephemeral port.
- E2E CI (`ci/external_fhir_ingestion_validation.sh`): updated the existing R4 assertions the migration invalidated and added a DSTU2 case (stub-Patient by identifier, `MedicationOrder`→`MedicationRequest` conversion, dangling-ref report, idempotent re-import). Ran green end-to-end during development. **Caveat:** not re-run live after the final assertion strengthening (local host ports were occupied); verified statically since.

## Follow-ups (non-blocking)

- `prefix_patient_ids()` in `main.py` is now dead code (only the migrated external path used it) — safe to remove in a cleanup pass.
- Optional request-body size guard on the internal converter sidecar.

## Design docs

- Spec: `docs/superpowers/specs/2026-08-20-dstu2-fhir-import-design.md`
- Plan: `docs/superpowers/plans/2026-08-20-dstu2-fhir-import.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
